### PR TITLE
Throw error with mandatory options

### DIFF
--- a/client/src/index.test.ts
+++ b/client/src/index.test.ts
@@ -16,6 +16,21 @@ interface User extends XataRecord {
 
 const users = new RestRepository<User>(client, 'users');
 
+describe('client', () => {
+  test('api key option is set', () => {
+    const client = new BaseClient({ apiKey: 'apiKey', databaseURL: 'url' }, {});
+    expect(client.options.apiKey).toBe('apiKey');
+    expect(client.options.databaseURL).toBe('url');
+  });
+
+  test('throws if mandatory options are missing', () => {
+    // @ts-expect-error Options are mandatory in TypeScript
+    expect(() => new BaseClient({ apiKey: null, databaseURL: null }, {})).toThrow(
+      'Options databaseURL and apiKey are required'
+    );
+  });
+});
+
 describe('request', () => {
   test('builds the right arguments for a GET request', async () => {
     fetch.mockReset().mockImplementation(() => {

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -305,9 +305,6 @@ export class RestRepository<T> extends Repository<T> {
 
   async request(method: string, path: string, body?: unknown) {
     const { databaseURL, apiKey } = this.client.options;
-    if (!databaseURL || !apiKey) {
-      throw new Error('Options databaseURL and apiKey are required');
-    }
 
     const resp: Response = await this.fetch(`${databaseURL}${path}`, {
       method,
@@ -410,6 +407,10 @@ export class BaseClient<D extends Record<string, Repository<any>>> {
   db!: D;
 
   constructor(options: XataClientOptions, links: Links) {
+    if (!options.databaseURL || !options.apiKey) {
+      throw new Error('Options databaseURL and apiKey are required');
+    }
+
     this.options = options;
     this.links = links;
   }

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -304,13 +304,17 @@ export class RestRepository<T> extends Repository<T> {
   }
 
   async request(method: string, path: string, body?: unknown) {
-    const { databaseURL } = this.client.options;
+    const { databaseURL, apiKey } = this.client.options;
+    if (!databaseURL || !apiKey) {
+      throw new Error('Options databaseURL and apiKey are required');
+    }
+
     const resp: Response = await this.fetch(`${databaseURL}${path}`, {
       method,
       headers: {
         Accept: '*/*',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.client.options.apiKey}`
+        Authorization: `Bearer ${apiKey}`
       },
       body: JSON.stringify(body)
     });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test:watch": "jest --watch",
     "prepare": "husky install",
     "build-example": "cd codegen && npm run example-ts && npm run example-js"
   },


### PR DESCRIPTION
If the parameters are not set or the env variables are ``undefined``﻿, the  client gives a message that fetch expects and absolute url, instead adding a more meaningful error message.

Since it's a public facing API we should do this validations, in case the SDK is used from JavaScript instead of TS.