### PR TITLE
Always fetch the CLI

### DIFF
--- a/codegen/src/getCli.ts
+++ b/codegen/src/getCli.ts
@@ -8,7 +8,6 @@ import { Ora } from 'ora';
 import { createReadStream, createWriteStream } from 'fs';
 
 import { cliPath } from './cliPath';
-import chalk from 'chalk';
 import { getCliPlatformFromNodePlatform } from './getCliPlatformFromNodePlatform';
 
 type GitHubResponse = {
@@ -16,13 +15,6 @@ type GitHubResponse = {
 };
 
 export const getCli = async ({ spinner }: { spinner: Ora }) => {
-  console.log();
-  spinner.info(
-    `You don't have the Xata CLI installed on your system, so we're downloading it. You could make this process faster by installing the CLI locally. More info: ${chalk.blueBright(
-      'https://docs.xata.io/cli/getting-started'
-    )}.
-`
-  );
   spinner.start('Looking up latest Xata CLI...');
   const fileUrl = await fetch('https://api.github.com/repos/xataio/cli/releases/latest')
     .then((r) => r.json())

--- a/codegen/src/getCli.ts
+++ b/codegen/src/getCli.ts
@@ -16,24 +16,19 @@ type GitHubResponse = {
 
 export const getCli = async ({ spinner }: { spinner: Ora }) => {
   spinner.start('Looking up latest Xata CLI...');
-  const fileUrl = await fetch('https://api.github.com/repos/xataio/cli/releases/latest')
-    .then((r) => r.json())
+  const fileUrl = await fetch('https://api.github.com/repos/xataio/cli/releases/skizzy')
+    .then(async (r) => {
+      if (!r.ok) {
+        throw errors.noCli;
+      }
+      return r.json();
+    })
     .then((d: GitHubResponse) =>
       d.assets.map((a) => a.browser_download_url).find((a) => a.includes(getCliPlatformFromNodePlatform()))
     );
 
   if (!fileUrl) {
-    spinner.fail(
-      `Could not find an appropriate version of the Xata CLI. This could be because:
-      
-1. No Xata CLI could be found for this platform (${process.platform}). 
-2. A release of the CLI was not correctly generated.
-3. A new release of the CLI is currently being rolled out.
-
-Please open an issue at https://github.com/xataio/cli and we'll address this as soon as we can. We apologize for the inconvenience.
-`
-    );
-    return;
+    throw errors.noCli;
   }
 
   spinner.text = 'Downloading latest Xata CLI...';
@@ -65,4 +60,15 @@ Please open an issue at https://github.com/xataio/cli and we'll address this as 
   }
 
   spinner.succeed('Xata CLI now available.');
+};
+
+const errors = {
+  noCli: new Error(`Could not find an appropriate version of the Xata CLI. This could be because:
+      
+  1. No Xata CLI could be found for this platform (${process.platform}). 
+  2. A release of the CLI was not correctly generated.
+  3. A new release of the CLI is currently being rolled out.
+  
+  Please open an issue at https://github.com/xataio/cli and we'll address this as soon as we can. We apologize for the inconvenience.
+  `)
 };

--- a/codegen/src/index.ts
+++ b/codegen/src/index.ts
@@ -6,7 +6,6 @@ import { access } from 'fs/promises';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 
-import { checkIfCliInstalled } from './checkIfCliInstalled';
 import { getCli } from './getCli';
 import { useCli } from './useCli';
 import { generateWithOutput } from './generateWithOutput';
@@ -61,13 +60,9 @@ program
       }
 
       spinner.text = 'Checking for Xata CLI...';
-      const hasCli = await checkIfCliInstalled();
 
       try {
-        if (!hasCli) {
-          await getCli({ spinner });
-        }
-
+        await getCli({ spinner });
         await useCli({ spinner });
         await generateWithOutput({
           schema: defaultSchemaPath,


### PR DESCRIPTION
## Summary

I had a local `xata` that was outdated and it caused problems during codegen. Given that `codegen` is not something that is frequently run, let's always fetch the latest Xata CLI and use it for codegen.

What problems you had during codegen?

### Status Quo

Currently, the codegen CLI works like this on first run:

- Check for Xata schema. If found, generate. 
    - If not found, ask a user if they want to pull a schema via the Xata CLI.
        - If yes, check for a `xata` command in the user's current PATH
            - If found, execute `xata init` and follow the (potentially outdated) Xata CLI's `init` flow to pull down a local schema
            - If not found, ask if they want to download the Xata CLI
                - If yes, fetch the latest release from GitHub, untar into `/tmp` and execute it. They follow the latest Xata CLI's `init` flow to pull down a local schema, generate code, and exit
                - If no, exit
        - If no, exit
    - If found, generate code and exit.

On subsequent runs, where `xata/schema.json` is present, it generates code and exit, assuming the user will `xata pull` as needed.

### What this PR changes

This PR skips the entire "check if local Xata CLI exists" step on first run, always using the latest version of the Xata CLI. Subsequent runs of the codegen command are identical to main.

- Check for Xata schema. If found, generate. 
    - If not found, ask a user if they want to pull a schema via the Xata CLI.
        - Fetch the latest release from GitHub, untar into `/tmp` and execute it. They follow the latest Xata CLI's `init` flow to pull down a local schema, generate code, and exit
        - If no, exit
    - If found, generate code and exit

### Why I Feel It's Necessary

This PR only affects the first run, and has the following benefits:

1. It removes assumptions about the user's environment and treats it as hostile by default. This gives us the best chance of first run success by using the latest Xata CLI release and not running into edge cases where their system might cause bugs.
2. It does not augment any behavior with codegen _after_ the first run.

### Tradeoffs

- **Pro**: The user always uses the most up-to-date version of the Xata CLI to pull down a schema on their first codegen attempt, without the potential for version mismatches and other issues that might prove hard to support. I imagine we'd need to ask them to run `which xata` or similar to check the version, etc. in GitHub support issues, which might be more friction-forward than we want.
- **Con**: If GitHub is down or they're having network issues, they will not be able to download and use the Xata CLI. This con also exists without this feature, as one way or another, they will still need to get a `xata/schema.json` from somewhere.