### PR TITLE
Use the xata command if exists locally

### DIFF
--- a/codegen/src/index.ts
+++ b/codegen/src/index.ts
@@ -11,6 +11,7 @@ import { getCli } from './getCli';
 import { useCli } from './useCli';
 import { generateWithOutput } from './generateWithOutput';
 import { handleXataCliRejection } from './handleXataCliRejection';
+import { cliPath } from './cliPath';
 
 const defaultSchemaPath = join(process.cwd(), 'xata', 'schema.json');
 const defaultOutputFile = join(process.cwd(), 'XataClient');
@@ -68,7 +69,7 @@ program
           await getCli({ spinner });
         }
 
-        await useCli({ spinner });
+        await useCli({ command: hasCli ? 'xata' : cliPath, spinner });
         await generateWithOutput({
           schema: defaultSchemaPath,
           out: defaultOutputFile,

--- a/codegen/src/useCli.ts
+++ b/codegen/src/useCli.ts
@@ -9,7 +9,7 @@ export const useCli = ({ command, spinner }: Options) =>
   new Promise<void>((resolve, reject) => {
     spinner.info('Delegating to Xata CLI...');
 
-    const cli = spawn(cliPath, ['init'], { stdio: ['inherit', 'pipe', 'pipe'] })
+    const cli = spawn(command, ['init'], { stdio: ['inherit', 'pipe', 'pipe'] })
       .on('close', (code) => {
         if (code !== 0) {
           return;
@@ -26,7 +26,7 @@ export const useCli = ({ command, spinner }: Options) =>
       }
 
       spinner.warn('Not logged into Xata CLI.');
-      const authProcess = spawn(cliPath, ['auth', 'login'], { stdio: 'inherit' });
+      const authProcess = spawn(command, ['auth', 'login'], { stdio: 'inherit' });
       authProcess.on('exit', (code) => {
         if (code === 0) useCli({ spinner, command });
       });

--- a/codegen/src/useCli.ts
+++ b/codegen/src/useCli.ts
@@ -3,7 +3,9 @@ import { Ora } from 'ora';
 
 import { cliPath } from './cliPath';
 
-export const useCli = ({ spinner }: { spinner: Ora }) =>
+type Options = { command: 'xata' | typeof cliPath; spinner: Ora };
+
+export const useCli = ({ command, spinner }: Options) =>
   new Promise<void>((resolve, reject) => {
     spinner.info('Delegating to Xata CLI...');
 
@@ -26,7 +28,7 @@ export const useCli = ({ spinner }: { spinner: Ora }) =>
       spinner.warn('Not logged into Xata CLI.');
       const authProcess = spawn(cliPath, ['auth', 'login'], { stdio: 'inherit' });
       authProcess.on('exit', (code) => {
-        if (code === 0) useCli({ spinner });
+        if (code === 0) useCli({ spinner, command });
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixing a bug where the codegen CLI always tries to use the Xata CLI from `tmpPath/xata`, even if the `xata` command is in a user's PATH and they've never downloaded the Xata CLI to `tmpPath`.