### PR TITLE
Remove summary section from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-## Summary
-
 <!-- Add a nice description here -->
 
 <!-- Don't forget the `Closed #{issue_number}` -->


### PR DESCRIPTION
Usually our descriptions are short, so the summary part is a bit unnecessary, IMO.