### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import { XataClient } from './xata';
 const client = new XataClient({
   branch: 'branchname',
   apiKey: 'xau_1234abcdef',
-  fetch: fetchImplememntation // Required if your runtime doesn't provide a global `fetch` function.
+  fetch: fetchImplementation // Required if your runtime doesn't provide a global `fetch` function.
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ In a TypeScript file start using the generated code:
 import { XataClient } from './xata';
 
 const client = new XataClient({
-  databaseURL: 'https://myworkspace-123abc.xata.sh/db/databasename',
   branch: 'branchname',
   apiKey: 'xau_1234abcdef',
   fetch: fetchImplememntation // Required if your runtime doesn't provide a global `fetch` function.
@@ -46,7 +45,7 @@ const client = new XataClient({
 
 The import above will differ if you chose to genreate the types in a different location.
 
-`fetch` is required only if your runtime doesn't provide a global `fetch` function. However, if your runtime supports CJS, the SDK will try to also require `node-fetch` and `cross-fetch` if a `fetch` implementation is not provided.
+`XataClient` only has two required arguments: `branch` and `apiKey`. `fetch` is required only if your runtime doesn't provide a global `fetch` function. There's also a `databaseURL` argument that by default will contain a URL pointing to your database (e.g. `https://myworkspace-123abc.xata.sh/db/databasename`), it can be specified in the constructor to overwrite that value if for whatever reason you need to connect to a different workspace or database.
 
 ## API
 


### PR DESCRIPTION
- We don't require() well-known libraries anymore.
- Remove the `databaseURL` in the example, but explain that it can be specified.
