### PR TITLE
Fix fetch implementation with CF workers

### DIFF
--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -378,7 +378,7 @@ export abstract class Repository<T> extends Query<T, Selectable<T>> {
 
 export class RestRepository<T> extends Repository<T> {
   client: BaseClient<any>;
-  fetch: any;
+  fetchImpl: any;
 
   constructor(client: BaseClient<any>, table: string) {
     super(null, table, {});
@@ -386,10 +386,10 @@ export class RestRepository<T> extends Repository<T> {
 
     const fetchImpl = typeof fetch !== 'undefined' ? fetch : this.client.options.fetch;
     if (!fetchImpl) throw new Error('No fetch implementation provided');
-    this.fetch = fetchImpl;
+    this.fetchImpl = fetchImpl;
 
     Object.defineProperty(this, 'client', { enumerable: false });
-    Object.defineProperty(this, 'fetch', { enumerable: false });
+    Object.defineProperty(this, 'fetchImpl', { enumerable: false });
     Object.defineProperty(this, 'hostname', { enumerable: false });
   }
 
@@ -397,7 +397,7 @@ export class RestRepository<T> extends Repository<T> {
     const { databaseURL, apiKey } = this.client.options;
     const branch = await this.client.getBranch();
 
-    const resp: Response = await this.fetch(`${databaseURL}:${branch}${path}`, {
+    const resp: Response = await this.fetchImpl(`${databaseURL}:${branch}${path}`, {
       method,
       headers: {
         Accept: '*/*',

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -384,9 +384,16 @@ export class RestRepository<T> extends Repository<T> {
     super(null, table, {});
     this.client = client;
 
-    const fetchImpl = typeof fetch !== 'undefined' ? fetch : this.client.options.fetch;
-    if (!fetchImpl) throw new Error('No fetch implementation provided');
-    this.fetch = fetchImpl;
+    const doWeHaveFetch = typeof fetch !== 'undefined';
+    const isInjectedFetchProblematic = !this.client.options.fetch;
+
+    if (doWeHaveFetch) {
+      this.fetch = fetch;
+    } else if (isInjectedFetchProblematic) {
+      throw new Error(errors.falsyFetchImplementation);
+    } else {
+      this.fetch = this.client.options.fetch;
+    }
 
     Object.defineProperty(this, 'client', { enumerable: false });
     Object.defineProperty(this, 'fetch', { enumerable: false });

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -384,16 +384,9 @@ export class RestRepository<T> extends Repository<T> {
     super(null, table, {});
     this.client = client;
 
-    const doWeHaveFetch = typeof fetch !== 'undefined';
-    const isInjectedFetchProblematic = !this.client.options.fetch;
-
-    if (doWeHaveFetch) {
-      this.fetch = fetch;
-    } else if (isInjectedFetchProblematic) {
-      throw new Error(errors.falsyFetchImplementation);
-    } else {
-      this.fetch = this.client.options.fetch;
-    }
+    const fetchImpl = typeof fetch !== 'undefined' ? fetch : this.client.options.fetch;
+    if (!fetchImpl) throw new Error('No fetch implementation provided');
+    this.fetch = fetchImpl;
 
     Object.defineProperty(this, 'client', { enumerable: false });
     Object.defineProperty(this, 'fetch', { enumerable: false });

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -378,7 +378,7 @@ export abstract class Repository<T> extends Query<T, Selectable<T>> {
 
 export class RestRepository<T> extends Repository<T> {
   client: BaseClient<any>;
-  fetchImpl: any;
+  fetch: any;
 
   constructor(client: BaseClient<any>, table: string) {
     super(null, table, {});
@@ -386,18 +386,19 @@ export class RestRepository<T> extends Repository<T> {
 
     const fetchImpl = typeof fetch !== 'undefined' ? fetch : this.client.options.fetch;
     if (!fetchImpl) throw new Error('No fetch implementation provided');
-    this.fetchImpl = fetchImpl;
+    this.fetch = fetchImpl;
 
     Object.defineProperty(this, 'client', { enumerable: false });
-    Object.defineProperty(this, 'fetchImpl', { enumerable: false });
+    Object.defineProperty(this, 'fetch', { enumerable: false });
     Object.defineProperty(this, 'hostname', { enumerable: false });
   }
 
   async request<T>(method: string, path: string, body?: unknown): Promise<T | undefined> {
     const { databaseURL, apiKey } = this.client.options;
     const branch = await this.client.getBranch();
+    const fetchImpl = this.fetch;
 
-    const resp: Response = await this.fetchImpl(`${databaseURL}:${branch}${path}`, {
+    const resp: Response = await fetchImpl(`${databaseURL}:${branch}${path}`, {
       method,
       headers: {
         Accept: '*/*',


### PR DESCRIPTION
Closes: #59 

In #58 we plan to use the API methods internally and stop using ``fetch`` directly (which also solves the `Illegal Invocation` issue). This is only a fix so we can bump a ``patch`` version early and solve the compatibility with CF.