### PR TITLE
Add TS plugin to prettier call

### DIFF
--- a/codegen/src/codegen.ts
+++ b/codegen/src/codegen.ts
@@ -1,8 +1,7 @@
 import pluralize from 'pluralize';
-import type { BuiltInParserName } from 'prettier';
-import parserTypeScript from 'prettier/parser-typescript';
-import parserJavascript from 'prettier/parser-babel';
-import prettier from 'prettier/standalone';
+import prettier, { BuiltInParserName } from 'prettier';
+import parserJavascript from 'prettier/parser-babel.js';
+import parserTypeScript from 'prettier/parser-typescript.js';
 import ts from 'typescript';
 import { XataConfigSchema } from './config.js';
 import { Column, Table, XataDatabaseSchema } from './schema.js';

--- a/codegen/src/codegen.ts
+++ b/codegen/src/codegen.ts
@@ -1,6 +1,7 @@
 import pluralize from 'pluralize';
 import type { BuiltInParserName } from 'prettier';
 import parserTypeScript from 'prettier/parser-typescript';
+import parserJavascript from 'prettier/parser-babel';
 import prettier from 'prettier/standalone';
 import ts from 'typescript';
 import { XataConfigSchema } from './config.js';
@@ -124,7 +125,7 @@ export async function generate({ schema, config, language, javascriptTarget }: G
 
   const transpiled = transpile(code, language, javascriptTarget);
 
-  return prettier.format(transpiled, { parser, plugins: [parserTypeScript] });
+  return prettier.format(transpiled, { parser, plugins: [parserTypeScript, parserJavascript] });
 }
 
 const prettierParsers: Record<Language, BuiltInParserName> = {

--- a/codegen/src/codegen.ts
+++ b/codegen/src/codegen.ts
@@ -1,6 +1,8 @@
 import pluralize from 'pluralize';
-import prettier, { BuiltInParserName } from 'prettier';
-import * as ts from 'typescript';
+import type { BuiltInParserName } from 'prettier';
+import parserTypeScript from 'prettier/parser-typescript';
+import prettier from 'prettier/standalone';
+import ts from 'typescript';
 import { XataConfigSchema } from './config.js';
 import { Column, Table, XataDatabaseSchema } from './schema.js';
 
@@ -122,7 +124,7 @@ export async function generate({ schema, config, language, javascriptTarget }: G
 
   const transpiled = transpile(code, language, javascriptTarget);
 
-  return prettier.format(transpiled, { parser });
+  return prettier.format(transpiled, { parser, plugins: [parserTypeScript] });
 }
 
 const prettierParsers: Record<Language, BuiltInParserName> = {


### PR DESCRIPTION
For usage in browser we need to manually pass the TS plugin

https://prettier.io/docs/en/browser.html

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
