### PR TITLE
Expose pagination limits

### DIFF
--- a/.changeset/rude-starfishes-relax.md
+++ b/.changeset/rude-starfishes-relax.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add new getAll() method

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -283,6 +283,12 @@ describe('integration tests', () => {
     expect(users).toHaveLength(mockUsers.length);
   });
 
+  test('get all users', async () => {
+    const users = await client.db.users.getAll();
+    expect(users).toHaveLength(mockUsers.length);
+    expect(users[0].id).toBeDefined();
+  });
+
   test('create single team', async () => {
     const team = await client.db.teams.create({ name: 'Team ships' });
 


### PR DESCRIPTION
- Expose constants for pagination limits (size 200 and offset 800)
- Add integration tests that ensure those values are up to date
- Finally allow schema-less client (using proxies)