### PR TITLE
Use custom git token to trigger builds after push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,5 @@ jobs:
           title: Release tracking
           publish: npx lerna publish from-package --no-verify-access --yes
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,5 +55,5 @@ jobs:
           title: Release tracking
           publish: npx lerna publish from-package --no-verify-access --yes
         env:
-          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ env.BRANCH }}
         uses: actions/github-script@0.4.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GIT_TOKEN }}
           script: |
             const {repo, owner} = context.repo;
             const {data:pr} = await github.pulls.create({


### PR DESCRIPTION
When se use the GITHUB_TOKEN to push changes to git, other workflows are not triggered. By using a custom GIT_TOKEN we should avoid that.