### PR TITLE
Make Selectable not "Identifiable"

### DIFF
--- a/.changeset/wicked-dots-fetch.md
+++ b/.changeset/wicked-dots-fetch.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Fix in Selectable type

--- a/client/src/schema/repository.ts
+++ b/client/src/schema/repository.ts
@@ -156,7 +156,7 @@ export class RestRepository<T extends XataRecord> extends Repository<T> {
       ...fetchProps
     });
 
-    const finalObjects = await this.any(...response.recordIDs.map((id) => this.filter('id', id))).getAll();
+    const finalObjects = await this.any(...response.recordIDs.map((id) => this.filter('id' as any, id))).getAll();
     if (finalObjects.length !== objects.length) {
       throw new Error('The server failed to save some records');
     }

--- a/client/src/schema/selection.ts
+++ b/client/src/schema/selection.ts
@@ -1,27 +1,13 @@
 import { XataRecord } from '..';
 import { StringKeys, UnionToIntersection, Values } from '../util/types';
 import { Query } from './query';
-import { Identifiable } from './record';
 
 type Queries<T> = {
   [key in keyof T as T[key] extends Query<any> ? key : never]: T[key];
 };
 
-type OmitQueries<T> = {
-  [key in keyof T as T[key] extends Query<any> ? never : key]: T[key];
-};
-
-type OmitLinks<T> = {
-  [key in keyof T as T[key] extends XataRecord ? never : key]: T[key];
-};
-
-type OmitMethods<T> = {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  [key in keyof T as T[key] extends Function ? never : key]: T[key];
-};
-
 type InternalProperties = keyof XataRecord;
-export type Selectable<T extends XataRecord> = Omit<T, InternalProperties> & Identifiable;
+export type Selectable<T extends XataRecord> = Omit<T, InternalProperties>;
 
 export type SelectableColumn<O> =
   | '*'

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -8,7 +8,7 @@ import {
   PAGINATION_MAX_OFFSET,
   PAGINATION_MAX_SIZE
 } from '../client/src/schema/pagination';
-import { User, XataClient } from '../codegen/example/xata';
+import { User, UserRecord, XataClient } from '../codegen/example/xata';
 import { mockUsers, teamColumns, userColumns } from './mock_data';
 
 // Get environment variables before reading them
@@ -278,7 +278,7 @@ describe('integration tests', () => {
   });
 
   test('repository implements pagination', async () => {
-    const loadUsers = async (repository: Repository<User>) => {
+    const loadUsers = async (repository: Repository<UserRecord>) => {
       return repository.getPaginated({ page: { size: 10 } });
     };
 
@@ -287,7 +287,7 @@ describe('integration tests', () => {
   });
 
   test('repository implements paginable', async () => {
-    async function foo(page: Paginable<User>): Promise<User[]> {
+    async function foo(page: Paginable<UserRecord>): Promise<User[]> {
       const nextPage = page.hasNextPage() ? await foo(await page.nextPage()) : [];
       return [...page.records, ...nextPage];
     }


### PR DESCRIPTION
I think it makes sense that Selectable doesn't extend from Identifiable. For all these methods the Selectable part is not expected to contain an id:

```ts
  abstract create(object: Selectable<T>): Promise<T>;
  abstract createMany(objects: Selectable<T>[]): Promise<T[]>;
  abstract insert(id: string, object: Selectable<T>): Promise<T>;
  abstract update(id: string, object: Partial<Selectable<T>>): Promise<T>;
  abstract updateOrInsert(id: string, object: Selectable<T>): Promise<T>;
```

Because either we specify an `id` as an argument, or the user can't specify an id (e.g. create).

If we need to make an argument Selectable and Identifiable let's make that specific to that case.
