### PR TITLE
Rename integration test

### DIFF
--- a/test/apiClient.test.ts
+++ b/test/apiClient.test.ts
@@ -39,7 +39,10 @@ describe('API Client Integration Tests', () => {
   });
 
   test('Create workspace with database, branch, table and records', async () => {
-    const { id: workspace } = await client.workspaces.createWorkspace({ name: 'example', slug: 'example' });
+    const { id: workspace } = await client.workspaces.createWorkspace({
+      name: 'sdk-integration-api-client',
+      slug: 'sdk-integration-api-client'
+    });
 
     const { databaseName } = await client.databases.createDatabase(workspace, 'database');
 


### PR DESCRIPTION
Rename so it's more clear in datadog

We should have some kind of scheduled gh action for clearing up old workspaces for our account (failed tests if any)

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
