### PR TITLE
Importer fixes

### DIFF
--- a/.changeset/early-frogs-raise.md
+++ b/.changeset/early-frogs-raise.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/importer': patch
+---
+
+Fix processing files larger than the batch size

--- a/importer/src/utils.test.ts
+++ b/importer/src/utils.test.ts
@@ -147,4 +147,8 @@ describe('parseRow', () => {
   test('parses multiples', () => {
     expect(parseRow(['[]', '[1,2,3]'], ['multiple', 'multiple'])).toEqual([[], ['1', '2', '3']]);
   });
+
+  test('parses emails', () => {
+    expect(parseRow(['', 'foo@example.com'], ['email', 'email'])).toEqual([null, 'foo@example.com']);
+  });
 });

--- a/importer/src/utils.ts
+++ b/importer/src/utils.ts
@@ -92,6 +92,8 @@ export function parseRow(values: string[], types: string[]) {
       return ['true', 'false'].includes(val) ? val === 'true' : null;
     } else if (type === 'multiple') {
       return parseArray(val);
+    } else if (type === 'email') {
+      return val || null;
     }
     return val;
   });


### PR DESCRIPTION
- Fix stopping / pausing the CSV importer. The csvtojson library in theory supports promises but was not waiting for the promise I was returning. Changing the callback to `async` to always return a promise and having a flag to stop processing lines when we decide, fixed error with files larger than the batch size.
- Use `null` instead of empty string for emails when an empty string is found. Otherwise the backend returns a 400.
