### PR TITLE
Add back lerna exec and remove force flag

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install new versions
         run: |
-          npm i --force
+          npm install && lerna exec npm install
           git add .
 
       - name: Create Pull Request

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -36,7 +36,7 @@
         "shx": "^0.3.4",
         "ts-node": "^10.8.0",
         "tslib": "^2.4.0",
-        "typescript": "^4.6.4"
+        "typescript": "^4.7.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7950,8 +7950,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "license": "Apache-2.0",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8733,9 +8734,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.0.tgz",
-      "integrity": "sha512-WZEwv0j0+dF0uNEBWkfMQsIaiahSQm60hAqXBJ0XYHRAZMUq8LyjMt7kD8NrfssxcqiRmmtxlipK+1PlwOXnBA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13985,7 +13986,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4"
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -14536,9 +14539,9 @@
       }
     },
     "zod": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.0.tgz",
-      "integrity": "sha512-WZEwv0j0+dF0uNEBWkfMQsIaiahSQm60hAqXBJ0XYHRAZMUq8LyjMt7kD8NrfssxcqiRmmtxlipK+1PlwOXnBA=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
     }
   }
 }

--- a/packages/codegen/package-lock.json
+++ b/packages/codegen/package-lock.json
@@ -20,9 +20,9 @@
         "pluralize": "^8.0.0",
         "prettier": "^2.6.2",
         "tar": "^6.1.11",
-        "typescript": "^4.6.4",
+        "typescript": "^4.7.2",
         "unzipper": "^0.10.11",
-        "zod": "^3.17.2"
+        "zod": "^3.17.3"
       },
       "bin": {
         "codegen": "dist/cli.js",
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1390,9 +1390,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/zod": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.2.tgz",
-      "integrity": "sha512-L8UPS2J/F3dIA8gsPTvGjd8wSRuwR1Td4AqR2Nw8r8BgcLIbZZ5/tCII7hbTLXTQDhxUnnsFdHwpETGajt5i3A==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2293,9 +2293,9 @@
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
     },
     "unzipper": {
       "version": "0.10.11",
@@ -2396,9 +2396,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zod": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.2.tgz",
-      "integrity": "sha512-L8UPS2J/F3dIA8gsPTvGjd8wSRuwR1Td4AqR2Nw8r8BgcLIbZZ5/tCII7hbTLXTQDhxUnnsFdHwpETGajt5i3A=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
     }
   }
 }

--- a/packages/importer/package-lock.json
+++ b/packages/importer/package-lock.json
@@ -17,7 +17,7 @@
         "inquirer": "^8.2.4",
         "ora": "^6.1.0",
         "transliteration": "^2.2.0",
-        "zod": "^3.17.2"
+        "zod": "^3.17.3"
       },
       "bin": {
         "importer": "dist/cli.js",
@@ -1023,9 +1023,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.2.tgz",
-      "integrity": "sha512-L8UPS2J/F3dIA8gsPTvGjd8wSRuwR1Td4AqR2Nw8r8BgcLIbZZ5/tCII7hbTLXTQDhxUnnsFdHwpETGajt5i3A==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1709,9 +1709,9 @@
       "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "zod": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.2.tgz",
-      "integrity": "sha512-L8UPS2J/F3dIA8gsPTvGjd8wSRuwR1Td4AqR2Nw8r8BgcLIbZZ5/tCII7hbTLXTQDhxUnnsFdHwpETGajt5i3A=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
+      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
     }
   }
 }


### PR DESCRIPTION
Without `lerna exec` we forget updating the monorepo internal packages lockfiles.

Also the ``force`` flag is needed in the frontend due outdated peer dependencies, but in the SDK we shouldn't face them.