### PR TITLE
CLI: Fix codegen language selection

### DIFF
--- a/.changeset/hip-taxis-remain.md
+++ b/.changeset/hip-taxis-remain.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fixes a bug that always generated TypeScript code

--- a/.changeset/hip-taxis-remain.md
+++ b/.changeset/hip-taxis-remain.md
@@ -2,4 +2,4 @@
 '@xata.io/cli': patch
 ---
 
-Fixes a bug that always generated TypeScript code
+Fixes a bug that make the CLI always generate TypeScript code

--- a/cli/src/commands/codegen/index.ts
+++ b/cli/src/commands/codegen/index.ts
@@ -45,7 +45,7 @@ export default class Codegen extends BaseCommand {
     }
 
     const databaseURL = await this.getDatabaseURL();
-    const result = await generateFromContext('typescript', { fetchImpl: fetch, databaseURL });
+    const result = await generateFromContext(language, { fetchImpl: fetch, databaseURL });
     const code = result.transpiled;
     const declarations = result.declarations;
 


### PR DESCRIPTION
TypeScript was hardcoded when in reallity we had the language in a variable already.

<!-- Don't forget the `Closed #{issue_number}` -->
