### PR TITLE
Fix CloudFlare workers require

### DIFF
--- a/.changeset/tall-suns-act.md
+++ b/.changeset/tall-suns-act.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Fixes a compatibility error in CloudFlare workers with latest version of wrangler

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -31,7 +31,7 @@ export async function getGitBranch(): Promise<string | undefined> {
   // Node.js: child_process.execSync
   try {
     if (typeof require === 'function') {
-      const req = require; //
+      const req = require; // Avoid "Detected a Node builtin module import while Node compatibility is disabled" in CloudFlare Workers
       return req('child_process').execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
     }
   } catch (err) {

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -30,8 +30,10 @@ export function getEnvVariable(name: string): string | undefined {
 export async function getGitBranch(): Promise<string | undefined> {
   // Node.js: child_process.execSync
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    return require('child_process').execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+    if (typeof require === 'function') {
+      const req = require; //
+      return req('child_process').execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+    }
   } catch (err) {
     // Ignore
   }


### PR DESCRIPTION
Avoid `Detected a Node builtin module import while Node compatibility is disabled` in CloudFlare workers.

Introduced here https://github.com/cloudflare/wrangler2/pull/1027

<!-- Don't forget the `Closed #{issue_number}` -->
