### PR TITLE
Move chunk to options object

### DIFF
--- a/.changeset/light-dolls-sleep.md
+++ b/.changeset/light-dolls-sleep.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': minor
+---
+
+Move chunk to options object

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -183,7 +183,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
   }
 
   async *[Symbol.asyncIterator](): AsyncIterableIterator<Result> {
-    for await (const [record] of this.getIterator(1)) {
+    for await (const [record] of this.getIterator({ chunk: 1 })) {
       yield record;
     }
   }

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -188,6 +188,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     }
   }
 
+  getIterator(): AsyncGenerator<Result[]>;
   getIterator(options: Omit<QueryOptions<Record>, 'columns' | 'page'> & { chunk?: number }): AsyncGenerator<Result[]>;
   getIterator<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'> & { chunk?: number }>(
     options: Options
@@ -231,6 +232,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
    * @param options Additional options to be used when performing the query.
    * @returns An array of records from the database.
    */
+  getAll(): Promise<Result[]>;
   getAll(options: Omit<QueryOptions<Record>, 'columns' | 'page'> & { chunk?: number }): Promise<Result[]>;
   getAll<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'> & { chunk?: number }>(
     options: Options

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -188,16 +188,14 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     }
   }
 
-  getIterator(chunk: number): AsyncGenerator<Result[]>;
-  getIterator(chunk: number, options: Omit<QueryOptions<Record>, 'columns' | 'page'>): AsyncGenerator<Result[]>;
-  getIterator<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'>>(
-    chunk: number,
+  getIterator(options: Omit<QueryOptions<Record>, 'columns' | 'page'> & { chunk?: number }): AsyncGenerator<Result[]>;
+  getIterator<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'> & { chunk?: number }>(
     options: Options
   ): AsyncGenerator<SelectedPick<Record, typeof options['columns']>[]>;
   async *getIterator<Result extends XataRecord>(
-    chunk: number,
-    options: QueryOptions<Record> = {}
+    options: QueryOptions<Record> & { chunk?: number } = {}
   ): AsyncGenerator<Result[]> {
+    const { chunk = 1 } = options;
     let offset = 0;
     let end = false;
 
@@ -233,19 +231,15 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
    * @param options Additional options to be used when performing the query.
    * @returns An array of records from the database.
    */
-  getAll(chunk?: number): Promise<Result[]>;
-  getAll(chunk: number | undefined, options: Omit<QueryOptions<Record>, 'columns' | 'page'>): Promise<Result[]>;
-  getAll<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'>>(
-    chunk: number | undefined,
+  getAll(options: Omit<QueryOptions<Record>, 'columns' | 'page'> & { chunk?: number }): Promise<Result[]>;
+  getAll<Options extends RequiredBy<Omit<QueryOptions<Record>, 'page'>, 'columns'> & { chunk?: number }>(
     options: Options
   ): Promise<SelectedPick<Record, typeof options['columns']>[]>;
-  async getAll<Result extends XataRecord>(
-    chunk = PAGINATION_MAX_SIZE,
-    options: QueryOptions<Record> = {}
-  ): Promise<Result[]> {
+  async getAll<Result extends XataRecord>(options: QueryOptions<Record> & { chunk?: number } = {}): Promise<Result[]> {
+    const { chunk = PAGINATION_MAX_SIZE, ...rest } = options;
     const results = [];
 
-    for await (const page of this.getIterator(chunk, options)) {
+    for await (const page of this.getIterator({ ...rest, chunk })) {
       results.push(...page);
     }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -307,7 +307,7 @@ describe('integration tests', () => {
   test('query implements iterator with chunks', async () => {
     const owners = [];
 
-    for await (const chunk of client.db.users.filter('full_name', contains('Owner')).getIterator(10)) {
+    for await (const chunk of client.db.users.filter('full_name', contains('Owner')).getIterator({ chunk: 10 })) {
       owners.push(...chunk);
     }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -307,7 +307,7 @@ describe('integration tests', () => {
   test('query implements iterator with chunks', async () => {
     const owners = [];
 
-    for await (const chunk of client.db.users.filter('full_name', contains('Owner')).getIterator({ chunk: 10 })) {
+    for await (const chunk of client.db.users.filter('full_name', contains('Owner')).getIterator({ batchSize: 10 })) {
       owners.push(...chunk);
     }
 


### PR DESCRIPTION
Closes: #269

It is very confusing that all methods have options as first and unique parameter, but getIterator/getAll have ``chunk, options``

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
