### PR TITLE
Fix createBranch with undefined from param

### DIFF
--- a/.changeset/cuddly-moles-look.md
+++ b/.changeset/cuddly-moles-look.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Do not send from param on undefined

--- a/cli/src/commands/branches/create.test.ts
+++ b/cli/src/commands/branches/create.test.ts
@@ -51,7 +51,7 @@ describe('branches create', () => {
     await expect(command.run()).rejects.toThrow('Something went wrong');
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA?from=');
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA');
     expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
   });
 
@@ -81,7 +81,7 @@ describe('branches create', () => {
     }
 
     expect(fetchMock).toHaveBeenCalledOnce();
-    expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA?from=');
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA');
     expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
 
     expect(log).toHaveBeenCalledTimes(json ? 0 : 1);
@@ -165,7 +165,7 @@ describe('branches create', () => {
       }
 
       expect(fetchMock).toHaveBeenCalledOnce();
-      expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA?from=');
+      expect(fetchMock.mock.calls[0][0]).toEqual('https://test-1234.xata.sh/db/test:featureA');
       expect(fetchMock.mock.calls[0][1].method).toEqual('PUT');
 
       expect(createBranch).toHaveBeenCalledOnce();

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,5 +1,6 @@
 import { getAPIKey } from '../util/apiKey';
 import { getFetchImplementation } from '../util/fetch';
+import { isString } from '../util/lang';
 import type * as Types from './components';
 import { operationsByTag } from './components';
 import type { FetcherExtraProps, FetchImpl } from './fetcher';
@@ -308,12 +309,12 @@ class BranchApi {
     workspace: Schemas.WorkspaceID,
     database: Schemas.DBName,
     branch: Schemas.BranchName,
-    from = '',
+    from?: string,
     options: Types.CreateBranchRequestBody = {}
   ): Promise<void> {
     return operationsByTag.branch.createBranch({
       pathParams: { workspace, dbBranchName: `${database}:${branch}` },
-      queryParams: { from },
+      queryParams: isString(from) ? { from } : undefined,
       body: options,
       ...this.extraProps
     });


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

Backend change: ``Error: from parameter cannot be empty when passed``
