### PR TITLE
Do not allow sending filter/sort with cursor

### DIFF
--- a/.changeset/polite-bottles-invite.md
+++ b/.changeset/polite-bottles-invite.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Do not allow filter/sort with cursor navigation

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -87,7 +87,6 @@ export class Page<Record extends XataRecord, Result extends XataRecord = Record>
 
 export type CursorNavigationOptions = { first?: string } | { last?: string } | { after?: string; before?: string };
 export type OffsetNavigationOptions = { size?: number; offset?: number };
-export type PaginationOptions = CursorNavigationOptions & OffsetNavigationOptions;
 
 export const PAGINATION_MAX_SIZE = 200;
 export const PAGINATION_DEFAULT_SIZE = 200;

--- a/packages/client/src/util/types.ts
+++ b/packages/client/src/util/types.ts
@@ -32,3 +32,5 @@ export type Exactly<T, U extends T = T> = U & Impossible<Exclude<keyof U, keyof 
 export type SingleOrArray<T> = T | T[];
 
 export type Dictionary<T> = Record<string, T>;
+
+export type OmitBy<T, K extends keyof T> = T extends any ? Omit<T, K> : never;


### PR DESCRIPTION
Closes: #274

Why did I need a new implementation of `Omit`:

<img width="325" alt="Screenshot 2022-06-09 at 16 13 07" src="https://user-images.githubusercontent.com/2181866/172868260-09ccb638-f2e2-4e55-8ce4-248c3b76d7b8.png">
<img width="345" alt="Screenshot 2022-06-09 at 16 13 13" src="https://user-images.githubusercontent.com/2181866/172868288-2c4cd1e6-82ac-4939-9272-b894d3f5f9b9.png">
