### PR TITLE
CLI init fixes

### DIFF
--- a/.changeset/nervous-dodos-hunt.md
+++ b/.changeset/nervous-dodos-hunt.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fixes an error when JS is used for the code generator. Also improves the CLI interactivity.

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -89,6 +89,7 @@ export default class Init extends BaseCommand {
       message: 'Do you want to use the TypeScript/JavaScript code generator?',
       initial: true
     });
+    if (confirm === undefined) return this.exit(1);
     if (!confirm) return;
 
     this.projectConfig = this.projectConfig || {};
@@ -108,8 +109,7 @@ export default class Init extends BaseCommand {
       const { declarations } = await prompts({
         type: 'confirm',
         name: 'declarations',
-        message: 'Do you want to generate the TypeScript declarations?',
-        initial: (prev) => !prev.endsWith('.ts')
+        message: 'Do you want to generate the TypeScript declarations?'
       });
 
       if (declarations) {

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -75,6 +75,7 @@ export default class Init extends BaseCommand {
       message: 'Do you want to install the TypeScript/JavaScript SDK?',
       initial: true
     });
+    if (confirm === undefined) return this.exit(1);
     if (!confirm) return;
 
     await this.installPackage('@xata.io/client');


### PR DESCRIPTION
This PR fixes

- Error when using the codegenerator and a JS file.
- Ctr+C when asked if installing the SDK or using the code generator.

<!-- Don't forget the `Closed #{issue_number}` -->
