### PR TITLE
Ignore `x-draft` openapi paths

### DIFF
--- a/openapi-codegen.config.ts
+++ b/openapi-codegen.config.ts
@@ -65,5 +65,5 @@ const isDraft = (operation: unknown) => {
     return false;
   }
 
-  return operation['x-internal'] === true;
+  return operation['x-draft'] === true;
 };

--- a/openapi-codegen.config.ts
+++ b/openapi-codegen.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@openapi-codegen/cli';
+import { Context } from '@openapi-codegen/cli/lib/types';
 import { addPathParam, generateFetchers, generateSchemaTypes, renameComponent } from '@openapi-codegen/typescript';
 
 export default defineConfig({
@@ -14,6 +15,8 @@ export default defineConfig({
     to: async (context) => {
       // TODO: Fix me, allow no filenamePrefix
       const filenamePrefix = ' ';
+
+      context.openAPIDocument = removeDraftPaths({ openAPIDocument: context.openAPIDocument });
 
       // Avoid conflict with typescript `Record<>` type helper
       context.openAPIDocument = renameComponent({
@@ -35,3 +38,32 @@ export default defineConfig({
     }
   }
 });
+
+function removeDraftPaths({ openAPIDocument }: { openAPIDocument: Context['openAPIDocument'] }) {
+  const paths = Object.fromEntries(
+    Object.entries(openAPIDocument.paths).map(([route, verbs]) => {
+      const updatedVerbs = Object.entries(verbs).reduce((acc, [verb, operation]) => {
+        if (isVerb(verb) && isDraft(operation)) {
+          return acc;
+        }
+
+        return { ...acc, [verb]: operation };
+      }, {});
+
+      return [route, updatedVerbs];
+    })
+  );
+
+  return { ...openAPIDocument, paths };
+}
+
+const isVerb = (verb: string): verb is 'get' | 'post' | 'patch' | 'put' | 'delete' =>
+  ['get', 'post', 'patch', 'put', 'delete'].includes(verb);
+
+const isDraft = (operation: unknown) => {
+  if (!operation || typeof operation !== 'object') {
+    return false;
+  }
+
+  return operation['x-internal'] === true;
+};


### PR DESCRIPTION
For reference: https://xata-hq.slack.com/archives/C025YC7KDPT/p1655279178278709