### PR TITLE
Cli fixes

### DIFF
--- a/.changeset/thick-pumpkins-tell.md
+++ b/.changeset/thick-pumpkins-tell.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Some fixes to the xata init and merge commands

--- a/cli/package.json
+++ b/cli/package.json
@@ -75,8 +75,23 @@
     ],
     "topicSeparator": " ",
     "topics": {
-      "hello": {
-        "description": "Say hello to the world and others"
+      "auth": {
+        "description": "Authenticate with Xata.io, logout or check the status of your auth configuration"
+      },
+      "branches": {
+        "description": "Create, list or delete branches"
+      },
+      "config": {
+        "description": "Get or set configuration values"
+      },
+      "dbs": {
+        "description": "Create, list or delete databases"
+      },
+      "schema": {
+        "description": "Edit the schema interactively or dump it to a JSON file"
+      },
+      "workspaces": {
+        "description": "Create, list or delete workspaces"
       }
     },
     "additionalHelpFlags": [

--- a/cli/package.json
+++ b/cli/package.json
@@ -78,7 +78,10 @@
       "hello": {
         "description": "Say hello to the world and others"
       }
-    }
+    },
+    "additionalHelpFlags": [
+      "-h"
+    ]
   },
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -37,8 +37,9 @@ export abstract class BaseCommand extends Command {
 
   #xataClient?: XataApiClient;
 
+  // The first place is the one used by default when running `xata init`
   // In the future we can support YAML
-  searchPlaces = ['package.json', `.${moduleName}rc`, `.${moduleName}rc.json`];
+  searchPlaces = [`.${moduleName}rc`, `.${moduleName}rc.json`, 'package.json'];
 
   static databaseURLFlag = Flags.string({
     name: 'databaseurl',

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -289,6 +289,14 @@ export abstract class BaseCommand extends Command {
   async getParsedDatabaseURL(databaseURLFlag?: string, allowCreate?: boolean) {
     const { databaseURL, source } = await this.getDatabaseURL(databaseURLFlag, allowCreate);
 
+    const info = this.parseDatabaseURL(databaseURL);
+    return {
+      ...info,
+      source
+    };
+  }
+
+  parseDatabaseURL(databaseURL: string) {
     const [protocol, , host, , database] = databaseURL.split('/');
     const [workspace] = (host || '').split('.');
     return {
@@ -296,8 +304,7 @@ export abstract class BaseCommand extends Command {
       protocol,
       host,
       database,
-      workspace,
-      source
+      workspace
     };
   }
 

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -394,14 +394,14 @@ export abstract class BaseCommand extends Command {
     }
 
     if (migration.removedTables) {
-      for (const tableName of Object.keys(migration.removedTables)) {
+      for (const tableName of migration.removedTables) {
         this.log(` ${chalk.bgWhite.red('DELETE table ')} ${tableName}`);
       }
     }
 
     if (migration.renamedTables) {
-      for (const tableName of Object.keys(migration.renamedTables)) {
-        this.log(` ${chalk.bgWhite.blue('RENAME table ')} ${tableName}`);
+      for (const renamedTable of migration.renamedTables) {
+        this.log(` ${chalk.bgWhite.blue('RENAME table ')} ${renamedTable.oldName} to ${renamedTable.newName}`);
       }
     }
 
@@ -415,12 +415,12 @@ export abstract class BaseCommand extends Command {
           }
         }
         if (tableMigration.removedColumns) {
-          for (const columnName of Object.keys(tableMigration.removedColumns)) {
+          for (const columnName of tableMigration.removedColumns) {
             this.log(` ${chalk.bgWhite.red('DELETE column ')} ${columnName}`);
           }
         }
         if (tableMigration.modifiedColumns) {
-          for (const [, columnMigration] of Object.entries(tableMigration.modifiedColumns)) {
+          for (const columnMigration of tableMigration.modifiedColumns) {
             this.log(` ${chalk.bgWhite.red('MODIFY column ')} ${columnMigration.old.name}`);
           }
         }

--- a/cli/src/commands/branches/list.ts
+++ b/cli/src/commands/branches/list.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { BaseCommand } from '../../base.js';
-import { currentGitBranch, listBranches } from '../../git.js';
+import { currentGitBranch, isGitRepo, listBranches } from '../../git.js';
 export default class BranchesList extends BaseCommand {
   static description = 'List branches';
 
@@ -22,8 +22,10 @@ export default class BranchesList extends BaseCommand {
     const xata = await this.getXataClient();
     const { branches } = await xata.branches.getBranchList(workspace, database);
     const { mapping } = await xata.databases.getGitBranchesMapping(workspace, database);
-    const gitBranches = listBranches();
-    const current = currentGitBranch();
+
+    const git = isGitRepo();
+    const gitBranches = git ? listBranches() : [];
+    const current = git ? currentGitBranch() : null;
 
     const data = branches.map((branch) => {
       const { gitBranch } = mapping.find(({ xataBranch }) => xataBranch === branch.name) ?? {};

--- a/cli/src/commands/dbs/list.ts
+++ b/cli/src/commands/dbs/list.ts
@@ -19,7 +19,10 @@ export default class DatabasesList extends BaseCommand {
 
   async run(): Promise<any> {
     const { flags } = await this.parse(DatabasesList);
-    const workspace = flags.workspace || (await this.getWorkspace());
+    const workspace =
+      flags.workspace ||
+      this.parseDatabaseURL(this.projectConfig?.databaseURL ?? '').workspace ||
+      (await this.getWorkspace());
 
     const xata = await this.getXataClient();
     const databaseList = await xata.databases.getDatabaseList(workspace);

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -10,7 +10,6 @@ import { BaseCommand } from '../../base.js';
 import { getProfile } from '../../credentials.js';
 import { xataDatabaseSchema } from '../../schema.js';
 import Codegen from '../codegen/index.js';
-import EditSchema from '../schema/edit.js';
 
 export default class Init extends BaseCommand {
   static description = 'Configure your working directory to work with a Xata database';
@@ -27,9 +26,7 @@ export default class Init extends BaseCommand {
     })
   };
 
-  static args = [
-    // TODO: add an arg for initial schema
-  ];
+  static args = [];
 
   async run(): Promise<void> {
     const { flags } = await this.parse(Init);
@@ -57,13 +54,17 @@ export default class Init extends BaseCommand {
     if (flags.schema) {
       const branch = await getCurrentBranchName();
       await this.readAndDeploySchema(workspace, database, branch, flags.schema);
-    } else {
-      await EditSchema.run([]);
     }
 
     await Codegen.runIfConfigured(this.projectConfig);
 
     this.log('Done. You are all set!');
+
+    this.log(
+      `Run ${chalk.bold('xata browse')} to edit the schema via UI, or ${chalk.bold(
+        'xata schema edit'
+      )} to edit the schema in the shell.`
+    );
   }
 
   async installSDK() {

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -38,6 +38,8 @@ export default class Init extends BaseCommand {
         );
       } else {
         this.warn(`Will overwrite ${this.projectConfigLocation} because ${chalk.bold('--force')} is being used`);
+        // Clean up the project ocnfiugration so the user is asked for workspace and database again
+        this.projectConfig = undefined;
       }
     }
 
@@ -58,10 +60,8 @@ export default class Init extends BaseCommand {
 
     await Codegen.runIfConfigured(this.projectConfig);
 
-    this.log('Done. You are all set!');
-
     this.log(
-      `Run ${chalk.bold('xata browse')} to edit the schema via UI, or ${chalk.bold(
+      `You are all set! Run ${chalk.bold('xata browse')} to edit the schema via UI, or ${chalk.bold(
         'xata schema edit'
       )} to edit the schema in the shell.`
     );

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import { getBranchMigrationPlan, getCurrentBranchName } from '@xata.io/client';
+import { getCurrentBranchName } from '@xata.io/client';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
 import { access, readFile, writeFile } from 'fs/promises';
@@ -155,15 +155,7 @@ export default class Init extends BaseCommand {
   async writeConfig() {
     // Reuse location when using --force
     if (!this.projectConfigLocation) {
-      const { location } = await prompts({
-        type: 'select',
-        name: 'location',
-        message: 'Select where to store your configuration',
-        choices: this.searchPlaces.map((place) => ({ title: place, value: place }))
-      });
-      if (!location) return this.error('You must select a location for the configuration file');
-
-      this.projectConfigLocation = path.join(process.cwd(), location);
+      this.projectConfigLocation = path.join(process.cwd(), this.searchPlaces[0]);
     }
     await this.updateConfig();
   }

--- a/cli/src/commands/merge/index.ts
+++ b/cli/src/commands/merge/index.ts
@@ -1,7 +1,6 @@
-import { getCurrentBranchDetails, Schemas } from '@xata.io/client';
-import fetch from 'node-fetch';
-import { BaseCommand } from '../../base.js';
+import { Schemas } from '@xata.io/client';
 import deepmerge from 'deepmerge';
+import { BaseCommand } from '../../base.js';
 import Codegen from '../codegen/index.js';
 
 export default class Merge extends BaseCommand {

--- a/cli/src/git.ts
+++ b/cli/src/git.ts
@@ -1,5 +1,15 @@
 import { spawnSync } from 'child_process';
 
+export function isGitRepo() {
+  try {
+    run('git', ['status', '--porcelain=v1']);
+    return true;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('not a git repository')) return false;
+    throw err;
+  }
+}
+
 export function isWorkingDirClean() {
   const out = run('git', ['status', '--porcelain=v1']);
   return out === '';


### PR DESCRIPTION
- Do not ask for project file configuration in `xata init`. Use `.xatarc` by default.
- Do not run `schema edit` in `xata init`. Leave a message suggesting it or editing the schema in the web UI.
- Ask again for workspace/db when using `xata init --force`.
- Fix some outputs when doing a merge or xata init with schema.
- Allow running `branches list` without a git repo.
- Use project workspace in dbs list by default
- Allow using -h to display help
- Add [topic descriptions](https://oclif.io/docs/topics#docsNav)