### PR TITLE
Use new table search with filters

### DIFF
--- a/.changeset/beige-deers-vanish.md
+++ b/.changeset/beige-deers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add filtering to search by table

--- a/.changeset/modern-days-deny.md
+++ b/.changeset/modern-days-deny.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add new API method for searching in a given table

--- a/cli/src/commands/shell/index.ts
+++ b/cli/src/commands/shell/index.ts
@@ -96,7 +96,7 @@ export default class Shell extends BaseCommand {
           if (['get', 'post', 'patch', 'put', 'delete'].includes(verb.toLowerCase())) {
             const body = rest.join(' ');
             return fetchApi(verb, path, body).then((result) => {
-              return postProcess(result, { table }, callback);
+              return postProcess(result, { table, deep: true }, callback);
             });
           }
 
@@ -154,13 +154,17 @@ function getDefaultEval() {
   return defaultEval;
 }
 
-function postProcess(result: any, options: { table: boolean }, callback: (err: Error | null, result: any) => void) {
+function postProcess(
+  result: any,
+  options: { table: boolean; deep?: boolean },
+  callback: (err: Error | null, result: any) => void
+) {
   const { table } = options;
   return callback(
     null,
     table
       ? console.table(result)
-      : typeof result === 'object'
+      : typeof result === 'object' && options.deep
       ? console.log(util.inspect(result, { showHidden: false, depth: null, colors: true }))
       : result
   );

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -667,6 +667,20 @@ class RecordsApi {
     });
   }
 
+  public searchTable(
+    workspace: Schemas.WorkspaceID,
+    database: Schemas.DBName,
+    branch: Schemas.BranchName,
+    tableName: Schemas.TableName,
+    query: Types.SearchTableRequestBody
+  ): Promise<Responses.SearchResponse> {
+    return operationsByTag.records.searchTable({
+      pathParams: { workspace, dbBranchName: `${database}:${branch}`, tableName },
+      body: query,
+      ...this.extraProps
+    });
+  }
+
   public searchBranch(
     workspace: Schemas.WorkspaceID,
     database: Schemas.DBName,

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -21,7 +21,7 @@ const api = new XataApiClient({
 });
 
 beforeAll(async () => {
-  /**const id = Math.round(Math.random() * 100000);
+  const id = Math.round(Math.random() * 100000);
 
   const database = await api.databases.createDatabase(workspace, `sdk-integration-test-search-${id}`);
   databaseName = database.databaseName;
@@ -63,24 +63,36 @@ beforeAll(async () => {
     labels: ['monkey', 'banana', 'apple', 'dolphin']
   });
 
-  await waitForSearchIndexing();**/
+  await waitForSearchIndexing();
 });
 
 afterAll(async () => {
-  //await api.databases.deleteDatabase(workspace, databaseName);
+  await api.databases.deleteDatabase(workspace, databaseName);
 });
 
 describe('search', () => {
-  test.skip('search teams by table', async () => {
+  test.skip('search in table', async () => {
     const owners = await client.db.users.search('Owner');
     expect(owners.length).toBeGreaterThan(0);
 
+    expect(owners.length).toBe(2);
     expect(owners[0].id).toBeDefined();
     expect(owners[0].full_name?.includes('Owner')).toBeTruthy();
     expect(owners[0].read).toBeDefined();
   });
 
-  test.skip('search by tables with filter', async () => {
+  test.skip('search in table with filtering', async () => {
+    const owners = await client.db.users.search('Owner', {
+      filter: { full_name: 'Owner of team animals' }
+    });
+
+    expect(owners.length).toBe(1);
+    expect(owners[0].id).toBeDefined();
+    expect(owners[0].full_name?.includes('Owner of team animals')).toBeTruthy();
+    expect(owners[0].read).toBeDefined();
+  });
+
+  test.skip('search by tables with multiple tables', async () => {
     const { users = [], teams = [] } = await client.search.byTable('fruits', { tables: ['teams', 'users'] });
 
     expect(users.length).toBeGreaterThan(0);
@@ -110,7 +122,7 @@ describe('search', () => {
     expect(teams[0].name?.includes('fruits')).toBeTruthy();
   });
 
-  test.skip('search all with filter', async () => {
+  test.skip('search all with multiple tables', async () => {
     const results = await client.search.all('fruits', { tables: ['teams', 'users'] });
 
     for (const result of results) {
@@ -126,7 +138,7 @@ describe('search', () => {
     }
   });
 
-  test.skip('search all with filter partial', async () => {
+  test.skip('search all with one table', async () => {
     const results = await client.search.all('fruits', { tables: ['teams'] });
 
     for (const result of results) {


### PR DESCRIPTION
``api.records.searchTable(workspace, database, branch, table, { query: "foo", filter: { name: "bar" } })``

``xata.db.table.search("foo", { filter: { name: "bar" } })``