### PR TITLE
Use cursor pagination with many operations

### DIFF
--- a/.changeset/tender-nails-burn.md
+++ b/.changeset/tender-nails-burn.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Fix offset errors with operations that affect many rows

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -1,3 +1,4 @@
+import { isDefined } from '../util/lang';
 import { Query } from './query';
 import { XataRecord } from './record';
 
@@ -92,3 +93,12 @@ export const PAGINATION_MAX_SIZE = 200;
 export const PAGINATION_DEFAULT_SIZE = 200;
 export const PAGINATION_MAX_OFFSET = 800;
 export const PAGINATION_DEFAULT_OFFSET = 0;
+
+export function isCursorPaginationOptions(
+  options: Record<string, unknown> | undefined | null
+): options is CursorNavigationOptions {
+  return (
+    isDefined(options) &&
+    (isDefined(options.first) || isDefined(options.last) || isDefined(options.after) || isDefined(options.before))
+  );
+}

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -4,6 +4,7 @@ import { NonEmptyArray, OmitBy, RequiredBy } from '../util/types';
 import { Filter } from './filters';
 import {
   CursorNavigationOptions,
+  isCursorPaginationOptions,
   OffsetNavigationOptions,
   Page,
   Paginable,
@@ -53,7 +54,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     repository: Repository<Record> | null,
     table: string,
     data: Partial<QueryOptions<Record>>,
-    parent?: Partial<QueryOptions<Record>>
+    rawParent?: Partial<QueryOptions<Record>>
   ) {
     this.#table = table;
 
@@ -62,6 +63,9 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     } else {
       this.#repository = this as any;
     }
+
+    // Clean parent query options if new query is cursor based
+    const parent = cleanParent(data, rawParent);
 
     this.#data.filter = data.filter ?? parent?.filter ?? {};
     this.#data.filter.$any = data.filter?.$any ?? parent?.filter?.$any;
@@ -316,4 +320,17 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
   hasNextPage(): boolean {
     return this.meta.page.more;
   }
+}
+
+// When using cursor based pagination, it is not allowed to send new sorting/filtering
+// We removed the sorting/filtering from the query options to avoid the error from the API
+function cleanParent<Record extends XataRecord>(
+  data: Partial<QueryOptions<Record>>,
+  parent?: Partial<QueryOptions<Record>>
+) {
+  if (isCursorPaginationOptions(data.pagination)) {
+    return { ...parent, sorting: undefined, filter: undefined };
+  }
+
+  return parent;
 }

--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -19,7 +19,7 @@ import { isObject, isString } from '../util/lang';
 import { Dictionary } from '../util/types';
 import { CacheImpl } from './cache';
 import { Filter } from './filters';
-import { isCursorPaginationOptions, Page } from './pagination';
+import { Page } from './pagination';
 import { Query } from './query';
 import { BaseData, EditableData, Identifiable, isIdentifiable, XataRecord } from './record';
 import { SelectedPick } from './selection';

--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -19,7 +19,7 @@ import { isObject, isString } from '../util/lang';
 import { Dictionary } from '../util/types';
 import { CacheImpl } from './cache';
 import { Filter } from './filters';
-import { Page } from './pagination';
+import { isCursorPaginationOptions, Page } from './pagination';
 import { Query } from './query';
 import { BaseData, EditableData, Identifiable, isIdentifiable, XataRecord } from './record';
 import { SelectedPick } from './selection';
@@ -484,9 +484,14 @@ export class RestRepository<Data extends BaseData, Record extends XataRecord = D
 
     const data = query.getQueryOptions();
 
+    const filter = Object.values(data.filter ?? {}).some(Boolean) ? data.filter : undefined;
+    const sort = data.sort !== undefined ? buildSortFilter(data.sort) : undefined;
+    // Ignore filters and sorting when doing cursor pagination
+    const isCursorPagination = isCursorPaginationOptions(data.pagination);
+
     const body = {
-      filter: Object.values(data.filter ?? {}).some(Boolean) ? data.filter : undefined,
-      sort: data.sort !== undefined ? buildSortFilter(data.sort) : undefined,
+      filter: isCursorPagination ? undefined : filter,
+      sort: isCursorPagination ? undefined : sort,
       page: data.pagination,
       columns: data.columns
     };

--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -484,14 +484,9 @@ export class RestRepository<Data extends BaseData, Record extends XataRecord = D
 
     const data = query.getQueryOptions();
 
-    const filter = Object.values(data.filter ?? {}).some(Boolean) ? data.filter : undefined;
-    const sort = data.sort !== undefined ? buildSortFilter(data.sort) : undefined;
-    // Ignore filters and sorting when doing cursor pagination
-    const isCursorPagination = isCursorPaginationOptions(data.pagination);
-
     const body = {
-      filter: isCursorPagination ? undefined : filter,
-      sort: isCursorPagination ? undefined : sort,
+      filter: Object.values(data.filter ?? {}).some(Boolean) ? data.filter : undefined,
+      sort: data.sort !== undefined ? buildSortFilter(data.sort) : undefined,
       page: data.pagination,
       columns: data.columns
     };

--- a/packages/client/src/util/lang.ts
+++ b/packages/client/src/util/lang.ts
@@ -16,8 +16,12 @@ export function isObject(value: any): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+export function isDefined<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
 export function isString(value: any): value is string {
-  return value !== undefined && value !== null && typeof value === 'string';
+  return isDefined(value) && typeof value === 'string';
 }
 
 export function toBase64(value: string): string {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,16 +2,15 @@ import { execSync } from 'child_process';
 import fetch from 'cross-fetch';
 import dotenv from 'dotenv';
 import { join } from 'path';
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { BaseClient, contains, isXataRecord, lt, Repository, XataApiClient } from '../packages/client/src';
-import { FetchImpl } from '../packages/client/src/api/fetcher';
-import { getCurrentBranchName } from '../packages/client/src/util/config';
 import {
   Paginable,
   PAGINATION_DEFAULT_SIZE,
   PAGINATION_MAX_OFFSET,
   PAGINATION_MAX_SIZE
 } from '../packages/client/src/schema/pagination';
+import { getCurrentBranchName } from '../packages/client/src/util/config';
 import { User, UserRecord, XataClient } from '../packages/codegen/example/xata';
 import { mockUsers, teamColumns, userColumns } from './mock_data';
 
@@ -266,7 +265,7 @@ describe('integration tests', () => {
     expect(page2And3.records).toEqual([...page2.records, ...page3.records]);
   });
 
-  test('fails if sending cursor with sorting', async () => {
+  test('we ignore sorting if sending it with cursor', async () => {
     const page1 = await client.db.users.getPaginated({ pagination: { size: 5 } });
     const { records: records1, meta } = page1;
     const page2 = await page1.nextPage();
@@ -300,7 +299,7 @@ describe('integration tests', () => {
         pagination: { after: meta.page.cursor },
         sort: { column: 'full_name', direction: 'asc' }
       })
-    ).rejects.toThrow();
+    ).resolves.toBeDefined();
   });
 
   test('repository implements pagination', async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -265,7 +265,7 @@ describe('integration tests', () => {
     expect(page2And3.records).toEqual([...page2.records, ...page3.records]);
   });
 
-  test('we ignore sorting if sending it with cursor', async () => {
+  test('fails if sending cursor with sorting', async () => {
     const page1 = await client.db.users.getPaginated({ pagination: { size: 5 } });
     const { records: records1, meta } = page1;
     const page2 = await page1.nextPage();
@@ -299,7 +299,7 @@ describe('integration tests', () => {
         pagination: { after: meta.page.cursor },
         sort: { column: 'full_name', direction: 'asc' }
       })
-    ).resolves.toBeDefined();
+    ).rejects.toThrow();
   });
 
   test('repository implements pagination', async () => {


### PR DESCRIPTION
Closes: #314 

- Change internal methods to use cursor navigation instead of offset navigation
- Behaviour change: Ignore ``sorting/filtering`` when sending cursor navigation.
  - Backend would fail with that request
  - In userland TypeScript type guards do not allow it
  - Our internal methods could still generate bad queries
  - Ignore them for our internal methods and JavaScript users

Regarding this behaviour change, I have mixed feelings to be honest. I kind of like that we do not error out on impossible situations, but could mislead a JavaScript user who doesn't have type support.