### PR TITLE
Allow different ways to use tables filters

### DIFF
--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -169,7 +169,7 @@ describe('search', () => {
 
   test.skip('search all with filters', async () => {
     const results = await client.search.all('fruits', {
-      filter: { teams: { name: 'Team fruits' } }
+      tables: [{ table: 'teams', filter: { name: 'Team fruits' } }, 'users']
     });
 
     expect(results.length).toBe(1);


### PR DESCRIPTION
```
{
  "tables": [
    "teams",
    {
      "table": "users",
      "filter": <filter>,
    }
  ]
}
```