### PR TITLE
Fix too permissive regular expression in importer package

### DIFF
--- a/.changeset/famous-gifts-pretend.md
+++ b/.changeset/famous-gifts-pretend.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/importer': patch
+---
+
+Fix too permissive regular expression in importer package

--- a/packages/importer/src/utils.test.ts
+++ b/packages/importer/src/utils.test.ts
@@ -41,6 +41,7 @@ describe('guessType', () => {
     expect(guessType('foo')).toBe('string');
     expect(guessType('foo\nbar')).toBe('text');
     expect(guessType('foo@example.com')).toBe('email');
+    expect(guessType('not an email, even though it contains foo@bar.com')).toBe('string');
     expect(guessType('[1,2,3]')).toBe('multiple');
     expect(guessType('true')).toBe('bool');
     expect(guessType('false')).toBe('bool');

--- a/packages/importer/src/utils.ts
+++ b/packages/importer/src/utils.ts
@@ -58,7 +58,7 @@ export function guessType(value: string) {
     return 'float';
   } else if (['true', 'false'].includes(value)) {
     return 'bool';
-  } else if (value.match(/\S+@\S+.\S+/)) {
+  } else if (value.match(/^\S+@\S+\.\S+$/)) {
     return 'email';
   } else if (parseArray(value)) {
     return 'multiple';


### PR DESCRIPTION
Mainly it was missing ^ and $ to match the whole string, not just a substring.

<!-- Don't forget the `Closed #{issue_number}` -->
