### PR TITLE
Change --databaseURL flag to --db

### DIFF
--- a/.changeset/tender-cougars-accept.md
+++ b/.changeset/tender-cougars-accept.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': minor
+---
+
+Changed --databaseURL flag to --db

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -44,6 +44,7 @@ export abstract class BaseCommand extends Command {
 
   static databaseURLFlag = {
     db: Flags.string({
+      helpValue: 'https://{workspace}.xata.sh/db/{database}',
       description: 'URL of the database in the format https://{workspace}.xata.sh/db/{database}'
     })
   };

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -42,10 +42,11 @@ export abstract class BaseCommand extends Command {
   // In the future we can support YAML
   searchPlaces = [`.${moduleName}rc`, `.${moduleName}rc.json`, 'package.json'];
 
-  static databaseURLFlag = Flags.string({
-    name: 'databaseurl',
-    description: 'URL of the database in the format https://{workspace}.xata.sh/db/{database}'
-  });
+  static databaseURLFlag = {
+    db: Flags.string({
+      description: 'URL of the database in the format https://{workspace}.xata.sh/db/{database}'
+    })
+  };
 
   static branchFlag = Flags.string({
     name: 'branch',

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -99,7 +99,7 @@ export abstract class BaseCommand extends Command {
       this.error('Could not instantiate Xata client. No API key found.', {
         suggestions: [
           'Run `xata auth login`',
-          'Configure a project with `xata init --databaseURL=https://{workspace}.xata.sh/db/{database}`'
+          'Configure a project with `xata init --db=https://{workspace}.xata.sh/db/{database}`'
         ]
       });
     }

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -47,7 +47,7 @@ export abstract class BaseCommand extends Command {
   static databaseURLFlag = {
     db: Flags.string({
       helpValue: 'https://{workspace}.xata.sh/db/{database}',
-      description: 'URL of the database in the format https://{workspace}.xata.sh/db/{database}'
+      description: 'URL of the database'
     })
   };
 

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -27,6 +27,8 @@ const partialProjectConfig = projectConfigSchema.deepPartial();
 export type ProjectConfig = z.infer<typeof partialProjectConfig>;
 
 const moduleName = 'xata';
+const commonFlagsHelpGroup = 'Common';
+
 export abstract class BaseCommand extends Command {
   // Date formatting is not consistent across locales and timezones, so we need to set the locale and timezone for unit tests.
   // By default this will use the system locale and timezone.
@@ -51,14 +53,17 @@ export abstract class BaseCommand extends Command {
 
   static branchFlag = Flags.string({
     char: 'b',
+    helpValue: '<branch-name>',
     description: 'Branch name to use'
   });
 
   static noInputFlag = Flags.boolean({
+    helpGroup: commonFlagsHelpGroup,
     description: 'Will not prompt interactively for missing values'
   });
 
   static jsonFlag = Flags.boolean({
+    helpGroup: commonFlagsHelpGroup,
     description: 'Print the output in JSON format'
   });
 

--- a/cli/src/commands/branches/create.ts
+++ b/cli/src/commands/branches/create.ts
@@ -8,7 +8,7 @@ export default class BranchesCreate extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     from: Flags.string({
       description: 'Branch name to branch off from'
     }),
@@ -29,7 +29,7 @@ export default class BranchesCreate extends BaseCommand {
       return this.error('Please, specify a branch name');
     }
 
-    const { workspace, database } = await this.getParsedDatabaseURL(flags.databaseURL);
+    const { workspace, database } = await this.getParsedDatabaseURL(flags.db);
 
     const xata = await this.getXataClient();
 

--- a/cli/src/commands/branches/delete.ts
+++ b/cli/src/commands/branches/delete.ts
@@ -8,7 +8,7 @@ export default class BranchesDelete extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag
+    ...this.databaseURLFlag
   };
 
   static args = [{ name: 'branch', description: 'Branch name to delete', required: true }];
@@ -17,7 +17,7 @@ export default class BranchesDelete extends BaseCommand {
 
   async run(): Promise<void | unknown> {
     const { flags, args } = await this.parse(BranchesDelete);
-    const { workspace, database } = await this.getParsedDatabaseURL(flags.databaseURL);
+    const { workspace, database } = await this.getParsedDatabaseURL(flags.db);
     const branch = args.branch;
 
     const xata = await this.getXataClient();

--- a/cli/src/commands/branches/link.ts
+++ b/cli/src/commands/branches/link.ts
@@ -9,7 +9,7 @@ export default class BranchesCreate extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     git: Flags.string({
       description: 'Git branch name'
     }),
@@ -29,7 +29,7 @@ export default class BranchesCreate extends BaseCommand {
       this.error('Git cannot be found. Please install it to link branches.');
     }
 
-    const { workspace, database } = await this.getParsedDatabaseURL(flags.databaseURL);
+    const { workspace, database } = await this.getParsedDatabaseURL(flags.db);
 
     const xata = await this.getXataClient();
 

--- a/cli/src/commands/branches/list.ts
+++ b/cli/src/commands/branches/list.ts
@@ -8,7 +8,7 @@ export default class BranchesList extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag
+    ...this.databaseURLFlag
   };
 
   static args = [];
@@ -17,7 +17,7 @@ export default class BranchesList extends BaseCommand {
 
   async run(): Promise<any> {
     const { flags } = await this.parse(BranchesList);
-    const { workspace, database } = await this.getParsedDatabaseURL(flags.databaseURL);
+    const { workspace, database } = await this.getParsedDatabaseURL(flags.db);
 
     const xata = await this.getXataClient();
     const { branches } = await xata.branches.getBranchList(workspace, database);

--- a/cli/src/commands/branches/unlink.ts
+++ b/cli/src/commands/branches/unlink.ts
@@ -9,7 +9,7 @@ export default class BranchesCreate extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     git: Flags.string({
       description: 'Git branch name'
     })
@@ -26,7 +26,7 @@ export default class BranchesCreate extends BaseCommand {
       this.error('Git cannot be found. Please install it to unlink a branch.');
     }
 
-    const { workspace, database } = await this.getParsedDatabaseURL(flags.databaseURL);
+    const { workspace, database } = await this.getParsedDatabaseURL(flags.db);
 
     const xata = await this.getXataClient();
 

--- a/cli/src/commands/browse/index.ts
+++ b/cli/src/commands/browse/index.ts
@@ -9,7 +9,7 @@ export default class Browse extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: Flags.string({
       description: 'Branch to be browsed'
     })
@@ -21,7 +21,7 @@ export default class Browse extends BaseCommand {
     const { flags } = await this.parse(Browse);
     const base = (await getProfile())?.web || 'https://app.xata.io';
 
-    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.databaseURL, flags.branch);
+    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.db, flags.branch);
 
     await open(`${base}/workspaces/${workspace}/dbs/${database}/branches/${branch}`);
   }

--- a/cli/src/commands/codegen/index.ts
+++ b/cli/src/commands/codegen/index.ts
@@ -18,7 +18,7 @@ export default class Codegen extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag,
     output: Flags.string({
       char: 'o',
@@ -57,7 +57,7 @@ export default class Codegen extends BaseCommand {
 
     const xata = await this.getXataClient();
     const { workspace, database, branch, databaseURL } = await this.getParsedDatabaseURLWithBranch(
-      flags.databaseURL,
+      flags.db,
       flags.branch
     );
     const branchDetails = await xata.branches.getBranchDetails(workspace, database, branch);

--- a/cli/src/commands/import/csv.ts
+++ b/cli/src/commands/import/csv.ts
@@ -20,7 +20,7 @@ export default class ImportCSV extends BaseCommand {
 
   static flags = {
     'no-input': this.noInputFlag,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag,
     table: Flags.string({
       description: 'The table where the CSV file will be imported to',
@@ -57,7 +57,7 @@ export default class ImportCSV extends BaseCommand {
       'no-column-name-normalization': ignoreColumnNormalization
     } = flags;
 
-    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.databaseURL, flags.branch);
+    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.db, flags.branch);
 
     const xata = await this.getXataClient();
 

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -18,7 +18,7 @@ export default class Init extends BaseCommand {
   static examples = [];
 
   static flags = {
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     schema: Flags.string({
       description: 'Initializes a new database or updates an existing one with the given schema'
     }),
@@ -44,7 +44,7 @@ export default class Init extends BaseCommand {
       }
     }
 
-    const { workspace, database, databaseURL } = await this.getParsedDatabaseURL(flags.databaseURL, true);
+    const { workspace, database, databaseURL } = await this.getParsedDatabaseURL(flags.db, true);
 
     this.projectConfig = { databaseURL };
 

--- a/cli/src/commands/random-data/index.ts
+++ b/cli/src/commands/random-data/index.ts
@@ -9,7 +9,7 @@ export default class RandomData extends BaseCommand {
   static examples = [];
 
   static flags = {
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag,
     records: Flags.integer({
       description: 'Number of records to generate per table',
@@ -26,7 +26,7 @@ export default class RandomData extends BaseCommand {
   async run(): Promise<void> {
     const { flags } = await this.parse(RandomData);
 
-    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.databaseURL, flags.branch);
+    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.db, flags.branch);
     const xata = await this.getXataClient();
     const branchDetails = await xata.branches.getBranchDetails(workspace, database, branch);
     if (!branchDetails) {

--- a/cli/src/commands/schema/dump.ts
+++ b/cli/src/commands/schema/dump.ts
@@ -9,7 +9,7 @@ export default class SchemaDump extends BaseCommand {
   static examples = [];
 
   static flags = {
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag,
     file: Flags.string({ char: 'f', description: 'File to write the schma to' })
   };
@@ -19,7 +19,7 @@ export default class SchemaDump extends BaseCommand {
   async run(): Promise<Schemas.Schema | undefined> {
     const { flags } = await this.parse(SchemaDump);
 
-    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.databaseURL, flags.branch);
+    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.db, flags.branch);
 
     const xata = await this.getXataClient();
     const branchDetails = await xata.branches.getBranchDetails(workspace, database, branch);

--- a/cli/src/commands/schema/edit.ts
+++ b/cli/src/commands/schema/edit.ts
@@ -58,7 +58,7 @@ export default class EditSchema extends BaseCommand {
   static examples = [];
 
   static flags = {
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag
   };
 
@@ -73,7 +73,7 @@ export default class EditSchema extends BaseCommand {
 
   async run(): Promise<void> {
     const { flags } = await this.parse(EditSchema);
-    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.databaseURL, flags.branch);
+    const { workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(flags.db, flags.branch);
     this.workspace = workspace;
     this.database = database;
 

--- a/cli/src/commands/shell/index.ts
+++ b/cli/src/commands/shell/index.ts
@@ -23,7 +23,7 @@ export default class Shell extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    databaseURL: this.databaseURLFlag,
+    ...this.databaseURLFlag,
     branch: this.branchFlag,
     code: Flags.string({
       description: 'Fragment of code to be executed in the shell immediately after starting it'
@@ -36,7 +36,7 @@ export default class Shell extends BaseCommand {
     if (!apiKey)
       this.error('No API key found. Either use the XATA_API_KEY environment variable or run `xata auth login`');
     const { protocol, host, databaseURL, workspace, database, branch } = await this.getParsedDatabaseURLWithBranch(
-      flags.databaseURL,
+      flags.db,
       flags.branch
     );
 


### PR DESCRIPTION
See https://github.com/xataio/client-ts/pull/367#discussion_r908325418

I've decided to change the way we use it internally to:

```diff
  static flags = {
      ...this.commonFlags,
+     ...this.databaseURLFlag
-     databaseURL: this.databaseURLFlag
    };
```

I'll do the same with the other common flags. The benefit is that the name of the flag is not repeated.


Also in this PR I've put common flags in their own flag group.