### PR TITLE
Fix spawn usage on windows

### DIFF
--- a/.changeset/tasty-nails-trade.md
+++ b/.changeset/tasty-nails-trade.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/client": patch
+---
+
+Fix spawn usage on windows

--- a/.changeset/tasty-nails-trade.md
+++ b/.changeset/tasty-nails-trade.md
@@ -1,5 +1,5 @@
 ---
-"@xata.io/client": patch
+"@xata.io/cli": patch
 ---
 
 Fix spawn usage on windows

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -148,7 +148,7 @@ export default class Init extends BaseCommand {
   runCommand(command: string, args: string[]) {
     this.log(`Running ${command} ${args.join(' ')}`);
     return new Promise((resolve, reject) => {
-      spawn(command, args, { stdio: 'inherit' }).on('exit', (code) => {
+      spawn(command, args, { stdio: 'inherit', shell: true }).on('exit', (code) => {
         if (code && code > 0) return reject(new Error('Command failed'));
         resolve(undefined);
       });

--- a/cli/src/git.ts
+++ b/cli/src/git.ts
@@ -96,7 +96,7 @@ export function createBranch(name: string, base: string) {
 }
 
 function run(command: string, args: string[]) {
-  const result = spawnSync(command, args, { encoding: 'utf-8' });
+  const result = spawnSync(command, args, { encoding: 'utf-8', shell: true });
   if (result.error) throw result.error;
   if (result.status && result.status > 0) throw new Error(result.output.filter(Boolean).join('\n'));
   return result.output.filter(Boolean).join('\n').trim();


### PR DESCRIPTION
## Bug description
The `xata init` command was failing for me:

![image](https://user-images.githubusercontent.com/1761469/176873911-202f1d7d-9766-444e-8607-2b73e8518101.png)

## Resolution
Adding `{ shell: true}` seams to do the job.

## Reference
https://stackoverflow.com/questions/60386867/node-spawn-child-process-not-working-in-windows
