### PR TITLE
Implement --no-input and --force flags. Add flags for optionally reducing interactivity

### DIFF
--- a/cli/src/commands/auth/login.ts
+++ b/cli/src/commands/auth/login.ts
@@ -1,3 +1,4 @@
+import { Flags } from '@oclif/core';
 import { BaseCommand } from '../../base.js';
 import { getProfile, setProfile } from '../../credentials.js';
 
@@ -6,7 +7,9 @@ export default class Login extends BaseCommand {
 
   static examples = [];
 
-  static flags = {};
+  static flags = {
+    ...BaseCommand.forceFlag('Overwrite existing credentials if they exist')
+  };
 
   static args = [];
 

--- a/cli/src/commands/auth/login.ts
+++ b/cli/src/commands/auth/login.ts
@@ -1,4 +1,3 @@
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 import { getProfile, setProfile } from '../../credentials.js';
 
@@ -14,7 +13,7 @@ export default class Login extends BaseCommand {
   async run(): Promise<void> {
     const existingProfile = await getProfile(true);
     if (existingProfile) {
-      const { overwrite } = await prompts({
+      const { overwrite } = await this.prompt({
         type: 'confirm',
         name: 'overwrite',
         message: 'Authentication is already configured, do you want to overwrite it?'

--- a/cli/src/commands/auth/logout.ts
+++ b/cli/src/commands/auth/logout.ts
@@ -1,4 +1,3 @@
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 import { getProfile, removeProfile } from '../../credentials.js';
 
@@ -7,7 +6,9 @@ export default class Logout extends BaseCommand {
 
   static examples = [];
 
-  static flags = {};
+  static flags = {
+    ...BaseCommand.forceFlag()
+  };
 
   static args = [];
 
@@ -19,7 +20,8 @@ export default class Logout extends BaseCommand {
     const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
-      message: 'Are you sure you want to logout of Xata?'
+      message: 'Are you sure you want to logout of Xata?',
+      initial: true
     });
     if (!confirm) this.exit(2);
 

--- a/cli/src/commands/auth/logout.ts
+++ b/cli/src/commands/auth/logout.ts
@@ -16,7 +16,7 @@ export default class Logout extends BaseCommand {
     if (!existingProfile) {
       return this.error('You are not logged in');
     }
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: 'Are you sure you want to logout of Xata?'

--- a/cli/src/commands/branches/delete.ts
+++ b/cli/src/commands/branches/delete.ts
@@ -22,12 +22,15 @@ export default class BranchesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await this.prompt({
-      type: 'confirm',
-      name: 'confirm',
-      message: `Are you sure you want to delete the branch ${database}:${branch} in the ${workspace} workspace?`,
-      initial: false
-    });
+    const { confirm } = await this.prompt(
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Are you sure you want to delete the branch ${database}:${branch} in the ${workspace} workspace?`,
+        initial: false
+      },
+      flags.force
+    );
     if (!confirm) return this.exit(1);
 
     await xata.branches.deleteBranch(workspace, database, branch);

--- a/cli/src/commands/branches/delete.ts
+++ b/cli/src/commands/branches/delete.ts
@@ -1,4 +1,3 @@
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 
 export default class BranchesDelete extends BaseCommand {
@@ -8,7 +7,8 @@ export default class BranchesDelete extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
-    ...this.databaseURLFlag
+    ...this.databaseURLFlag,
+    ...BaseCommand.forceFlag()
   };
 
   static args = [{ name: 'branch', description: 'Branch name to delete', required: true }];
@@ -26,7 +26,7 @@ export default class BranchesDelete extends BaseCommand {
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete the branch ${database}:${branch} in the ${workspace} workspace?`,
-      initial: true
+      initial: false
     });
     if (!confirm) return this.exit(1);
 

--- a/cli/src/commands/branches/delete.ts
+++ b/cli/src/commands/branches/delete.ts
@@ -22,7 +22,7 @@ export default class BranchesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete the branch ${database}:${branch} in the ${workspace} workspace?`,

--- a/cli/src/commands/dbs/delete.ts
+++ b/cli/src/commands/dbs/delete.ts
@@ -25,7 +25,7 @@ export default class DatabasesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete database ${workspace}/${database}?`,

--- a/cli/src/commands/dbs/delete.ts
+++ b/cli/src/commands/dbs/delete.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 
 export default class DatabasesDelete extends BaseCommand {
@@ -9,6 +8,7 @@ export default class DatabasesDelete extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
+    ...BaseCommand.forceFlag(),
     workspace: Flags.string({
       description: 'Workspace id the database to delete belongs to'
     })
@@ -29,7 +29,7 @@ export default class DatabasesDelete extends BaseCommand {
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete database ${workspace}/${database}?`,
-      initial: true
+      initial: false
     });
     if (!confirm) return this.exit(1);
 

--- a/cli/src/commands/dbs/delete.ts
+++ b/cli/src/commands/dbs/delete.ts
@@ -25,12 +25,15 @@ export default class DatabasesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await this.prompt({
-      type: 'confirm',
-      name: 'confirm',
-      message: `Are you sure you want to delete database ${workspace}/${database}?`,
-      initial: false
-    });
+    const { confirm } = await this.prompt(
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Are you sure you want to delete database ${workspace}/${database}?`,
+        initial: false
+      },
+      flags.force
+    );
     if (!confirm) return this.exit(1);
 
     await xata.databases.deleteDatabase(workspace, database);

--- a/cli/src/commands/import/csv.ts
+++ b/cli/src/commands/import/csv.ts
@@ -1,7 +1,6 @@
 import { Flags } from '@oclif/core';
 import { CompareSchemaResult, createProcessor, parseCSVFile, parseCSVStream, TableInfo } from '@xata.io/importer';
 import chalk from 'chalk';
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 
 export default class ImportCSV extends BaseCommand {
@@ -21,6 +20,7 @@ export default class ImportCSV extends BaseCommand {
   static flags = {
     ...this.noInputFlag,
     ...this.databaseURLFlag,
+    ...BaseCommand.forceFlag('Update the schema database schema if necessary without asking'),
     branch: this.branchFlag,
     table: Flags.string({
       description: 'The table where the CSV file will be imported to',

--- a/cli/src/commands/import/csv.ts
+++ b/cli/src/commands/import/csv.ts
@@ -19,7 +19,7 @@ export default class ImportCSV extends BaseCommand {
   ];
 
   static flags = {
-    'no-input': this.noInputFlag,
+    ...this.noInputFlag,
     ...this.databaseURLFlag,
     branch: this.branchFlag,
     table: Flags.string({
@@ -105,7 +105,7 @@ export default class ImportCSV extends BaseCommand {
 
     if (compare.missingTable) {
       if (!create) {
-        const response = await prompts({
+        const response = await this.prompt({
           type: 'confirm',
           name: 'confirm',
           message: `Table ${table} does not exist. Do you want to create it?`,
@@ -115,7 +115,7 @@ export default class ImportCSV extends BaseCommand {
       }
     } else if (compare.missingColumns.length > 0) {
       if (!create) {
-        const response = await prompts({
+        const response = await this.prompt({
           type: 'confirm',
           name: 'confirm',
           message: `These columns are missing: ${missingColumnsList(compare)}. Do you want to create them?`,

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -70,7 +70,7 @@ export default class Init extends BaseCommand {
   }
 
   async installSDK() {
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: 'Do you want to install the TypeScript/JavaScript SDK?',
@@ -85,7 +85,7 @@ export default class Init extends BaseCommand {
   }
 
   async configureCodegen() {
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: 'Do you want to use the TypeScript/JavaScript code generator?',
@@ -97,7 +97,7 @@ export default class Init extends BaseCommand {
     this.projectConfig = this.projectConfig || {};
     this.projectConfig.codegen = {};
 
-    const { output } = await prompts({
+    const { output } = await this.prompt({
       type: 'text',
       name: 'output',
       message: 'Choose where the output file for the code generator',
@@ -108,7 +108,7 @@ export default class Init extends BaseCommand {
     this.projectConfig.codegen.output = output;
 
     if (!output.endsWith('.ts')) {
-      const { declarations } = await prompts({
+      const { declarations } = await this.prompt({
         type: 'confirm',
         name: 'declarations',
         message: 'Do you want to generate the TypeScript declarations?'

--- a/cli/src/commands/workspaces/delete.ts
+++ b/cli/src/commands/workspaces/delete.ts
@@ -24,12 +24,15 @@ export default class WorkspacesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await this.prompt({
-      type: 'confirm',
-      name: 'confirm',
-      message: `Are you sure you want to delete workspace ${workspace}?`,
-      initial: false
-    });
+    const { confirm } = await this.prompt(
+      {
+        type: 'confirm',
+        name: 'confirm',
+        message: `Are you sure you want to delete workspace ${workspace}?`,
+        initial: false
+      },
+      flags.force
+    );
     if (!confirm) return this.exit(1);
 
     await xata.workspaces.deleteWorkspace(workspace);

--- a/cli/src/commands/workspaces/delete.ts
+++ b/cli/src/commands/workspaces/delete.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import prompts from 'prompts';
 import { BaseCommand } from '../../base.js';
 
 export default class WorkspacesDelete extends BaseCommand {
@@ -9,6 +8,7 @@ export default class WorkspacesDelete extends BaseCommand {
 
   static flags = {
     ...this.commonFlags,
+    ...BaseCommand.forceFlag(),
     workspace: Flags.string({
       description: 'Workspace id to delete'
     })
@@ -28,7 +28,7 @@ export default class WorkspacesDelete extends BaseCommand {
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete workspace ${workspace}?`,
-      initial: true
+      initial: false
     });
     if (!confirm) return this.exit(1);
 

--- a/cli/src/commands/workspaces/delete.ts
+++ b/cli/src/commands/workspaces/delete.ts
@@ -24,7 +24,7 @@ export default class WorkspacesDelete extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const { confirm } = await prompts({
+    const { confirm } = await this.prompt({
       type: 'confirm',
       name: 'confirm',
       message: `Are you sure you want to delete workspace ${workspace}?`,


### PR DESCRIPTION
This PR:

- Wraps `prompts()` in a custom method that checks for interactivity.
- Allows specifying flags for values that can be also interactively requested.
- When interactivity is not possible it uses the `initial` value passed if exists.
- If not, it fails with specific messages.

TODO: see if we can simplify some flags conditionals with this new functionality.