### PR TITLE
Use which to calculate full path for running commands

### DIFF
--- a/.changeset/cool-ducks-march.md
+++ b/.changeset/cool-ducks-march.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fix executing npm/yarn on Windows

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -148,7 +148,7 @@ export default class Init extends BaseCommand {
   runCommand(command: string, args: string[]) {
     this.log(`Running ${command} ${args.join(' ')}`);
     return new Promise((resolve, reject) => {
-      spawn(command, args, { stdio: 'inherit' }).on('exit', (code) => {
+      spawn(which.sync(command), args, { stdio: 'inherit' }).on('exit', (code) => {
         if (code && code > 0) return reject(new Error('Command failed'));
         resolve(undefined);
       });


### PR DESCRIPTION
On Windows executing `npm` directly doesn't seem to work. Using the full path [seems to work](https://stackoverflow.com/questions/56366448/how-to-fix-error-spawn-npm-enoent-in-windows-10).