### PR TITLE
Improve staging and REST compatibility

### DIFF
--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -80,7 +80,7 @@ export default class Init extends BaseCommand {
     await this.writeEnvFile(workspace, database);
 
     if (flags.schema) {
-      const branch = await getCurrentBranchName();
+      const branch = await this.getCurrentBranchName(databaseURL);
       await this.readAndDeploySchema(workspace, database, branch, flags.schema);
     }
 

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -1,5 +1,4 @@
 import { Flags } from '@oclif/core';
-import { getCurrentBranchName } from '@xata.io/client';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
 import { highlight } from 'cli-highlight';

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -35,7 +35,7 @@ export const tableSchema = z.object({
 export type Table = z.infer<typeof tableSchema>;
 
 export const xataDatabaseSchema = z.object({
-  formatVersion: z.literal('1.0').or(z.literal('')),
+  formatVersion: z.literal('1.0').or(z.literal('')).optional(),
   tables: z.array(tableSchema)
 });
 

--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -35,7 +35,7 @@ export const tableSchema = z.object({
 export type Table = z.infer<typeof tableSchema>;
 
 export const xataDatabaseSchema = z.object({
-  formatVersion: z.literal('1.0'),
+  formatVersion: z.literal('1.0').or(z.literal('')),
   tables: z.array(tableSchema)
 });
 


### PR DESCRIPTION
- Generate `databaseURL` values that have into account the profile `api` setting.
- Introduce helper `getCurrentBranchName` function to be used in a couple of places.
- Accept an empty `formatVersion` (what the REST API sends) when parsing a schema.