### PR TITLE
Include request id in errors

### DIFF
--- a/.changeset/large-walls-flash.md
+++ b/.changeset/large-walls-flash.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Include request ids in error response

--- a/packages/client/src/api/errors.ts
+++ b/packages/client/src/api/errors.ts
@@ -13,18 +13,26 @@ class ErrorWithCause extends Error {
 
 export class FetcherError extends ErrorWithCause {
   public status: number | string;
+  public requestId: string | undefined;
   public errors: Responses.BulkError['errors'] | undefined;
 
-  constructor(status: number, data?: unknown) {
+  constructor(status: number, data?: unknown, requestId?: string) {
     super(getMessage(data));
 
     this.status = status;
     this.errors = isBulkError(data) ? data.errors : undefined;
+    this.requestId = requestId;
 
     if (data instanceof Error) {
       this.stack = data.stack;
       this.cause = (data as ErrorWithCause).cause;
     }
+  }
+
+  toString() {
+    const error = super.toString();
+
+    return `[${this.status}] (${this.requestId ?? 'Unknown'}): ${error}`;
   }
 }
 


### PR DESCRIPTION
We're getting some random non-JSON errors in CI

<img width="1097" alt="Screenshot 2022-07-13 at 10 40 01" src="https://user-images.githubusercontent.com/2181866/178690169-7a1f1612-3f2f-423b-92dd-fa394f1fd051.png">

The backend returns a `x-request-id` header that we can trace in the logs.

Make that all errors, read the header and include it, so that we can further track down issues ourselves and also that bug reports by users can be more helpful.