### PR TITLE
Fix constructor usage on hydrated `RecordArray`

### DIFF
--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -1,4 +1,4 @@
-import { isDefined } from '../util/lang';
+import { isDefined, isObject } from '../util/lang';
 import { Query } from './query';
 import { XataRecord } from './record';
 
@@ -117,11 +117,10 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
       return [];
     }
 
-    console.log('DEBUG', args.length, JSON.stringify(args), args);
-
-    // new RecordArray(page, [])
-    if (args.length <= 2 && Array.isArray(args[0].records) && Array.isArray(args[1] ?? [])) {
-      return new Array(...(args[0].records ?? args[1]));
+    // new RecordArray<T>(page: Page, overrideRecords: Array | undefined): T[>]
+    if (args.length <= 2 && isObject(args[0]?.meta) && Array.isArray(args[1] ?? [])) {
+      const result = args[1] ?? args[0].records ?? [];
+      return new Array(...result);
     }
 
     // <T>(...items: T[]): T[]

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -107,14 +107,23 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
   #page: Paginable<Result, Result>;
 
   constructor(page: Paginable<any, Result>, overrideRecords?: Result[]) {
-    super(...(overrideRecords ?? page.records ?? []));
-    if (typeof page === 'number') {
-      const error = new Error();
-      console.log(error.stack);
-    } else {
-      console.log('Valid', JSON.stringify(page));
-    }
+    super(...RecordArray.parseConstructorParams(page, overrideRecords));
     this.#page = page;
+  }
+
+  static parseConstructorParams(...args: any[]) {
+    // new <T>(arrayLength: number): T[]
+    if (typeof args[0] === 'number') {
+      return [];
+    }
+
+    // new RecordArray(page, [])
+    if (args.length <= 2 && Array.isArray(args[0].records) && Array.isArray(args[1] ?? [])) {
+      return new Array(...(args[0].records ?? args[1]));
+    }
+
+    // <T>(...items: T[]): T[]
+    return new Array(...args);
   }
 
   /**

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -108,7 +108,12 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
 
   constructor(page: Paginable<any, Result>, overrideRecords?: Result[]) {
     super(...(overrideRecords ?? page.records ?? []));
-    console.log('DEBUG', { overrideRecords, page });
+    if (typeof page === 'number') {
+      const error = new Error();
+      console.log(error.stack);
+    } else {
+      console.log('Valid', JSON.stringify(page));
+    }
     this.#page = page;
   }
 

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -113,8 +113,8 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
 
   static parseConstructorParams(...args: any[]) {
     // new <T>(arrayLength: number): T[]
-    if (typeof args[0] === 'number') {
-      return [];
+    if (args.length === 1 && typeof args[0] === 'number') {
+      return new Array(args[0]);
     }
 
     // new RecordArray<T>(page: Page, overrideRecords: Array | undefined): T[>]

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -107,7 +107,8 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
   #page: Paginable<Result, Result>;
 
   constructor(page: Paginable<any, Result>, overrideRecords?: Result[]) {
-    super(...(overrideRecords ?? page.records));
+    super(...(overrideRecords ?? page.records ?? []));
+    console.log('DEBUG', { overrideRecords, page });
     this.#page = page;
   }
 

--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -117,6 +117,8 @@ export class RecordArray<Result extends XataRecord> extends Array<Result> {
       return [];
     }
 
+    console.log('DEBUG', args.length, JSON.stringify(args), args);
+
     // new RecordArray(page, [])
     if (args.length <= 2 && Array.isArray(args[0].records) && Array.isArray(args[1] ?? [])) {
       return new Array(...(args[0].records ?? args[1]));


### PR DESCRIPTION
Closes: #427 