### PR TITLE
Do not print error in JSON format

### DIFF
--- a/cli/src/commands/schema/dump.ts
+++ b/cli/src/commands/schema/dump.ts
@@ -1,4 +1,4 @@
-import { Flags } from '@oclif/core';
+import { CliUx, Flags } from '@oclif/core';
 import { Schemas } from '@xata.io/client';
 import { writeFile } from 'fs/promises';
 import { BaseCommand } from '../../base.js';
@@ -24,14 +24,11 @@ export default class SchemaDump extends BaseCommand {
     const xata = await this.getXataClient();
     const branchDetails = await xata.branches.getBranchDetails(workspace, database, branch);
     if (!branchDetails) return this.error('Could not resolve the current branch');
-    if (!flags.file) return branchDetails.schema;
+    if (!flags.file) {
+      CliUx.ux.styledJSON(branchDetails.schema);
+      return branchDetails.schema;
+    }
 
     await writeFile(flags.file, JSON.stringify(branchDetails.schema, null, 2));
-  }
-
-  // By default the output is a JSON document. This removes the need to use --json
-  // to get the oclif JSON output functionality and coloring.
-  jsonEnabled() {
-    return true;
   }
 }


### PR DESCRIPTION
Using `CliUx.ux.styledJSON` directly without telling oclif that the command supports `--json`, avoids errors being printed as JSON too.

Closes https://github.com/xataio/client-ts/issues/426