### PR TITLE
CLI: fix creating link columns

### DIFF
--- a/.changeset/cyan-days-vanish.md
+++ b/.changeset/cyan-days-vanish.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fix error creating link columns with xata schema edit

--- a/cli/src/commands/schema/edit.ts
+++ b/cli/src/commands/schema/edit.ts
@@ -361,8 +361,7 @@ export default class EditSchema extends BaseCommand {
     });
 
     try {
-      const answer = await snippet.run();
-      const { values } = answer;
+      const { values } = await snippet.run();
       const col: Column = {
         name: values.name,
         type: values.type,


### PR DESCRIPTION
Closes https://github.com/xataio/client-ts/issues/406

The `answer.values` object is a flat structure and we need `{ link: { table: string } }` instead of `{ link: string }`

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
