### PR TITLE
Make env var override the xatarc config value

### DIFF
--- a/.changeset/pretty-trees-wash.md
+++ b/.changeset/pretty-trees-wash.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': minor
+---
+
+Re-order config values priority

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -341,8 +341,8 @@ export abstract class BaseCommand extends Command {
     allowCreate?: boolean
   ): Promise<{ databaseURL: string; source: 'flag' | 'config' | 'env' | 'interactive' }> {
     if (databaseURLFlag) return { databaseURL: databaseURLFlag, source: 'flag' };
-    if (this.projectConfig?.databaseURL) return { databaseURL: this.projectConfig.databaseURL, source: 'config' };
     if (process.env.XATA_DATABASE_URL) return { databaseURL: process.env.XATA_DATABASE_URL, source: 'env' };
+    if (this.projectConfig?.databaseURL) return { databaseURL: this.projectConfig.databaseURL, source: 'config' };
 
     const workspace = await this.getWorkspace({ allowCreate });
     const database = await this.getDatabase(workspace, { allowCreate });


### PR DESCRIPTION
Little fix about the priority of config values.

This should be `flag -> env var -> .xatarc` to be able to override the value on CI (as example)
