### PR TITLE
Update workflow to publish releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.7.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "xataio/client-ts" }],
-  "commit": true,
+  "commit": false,
   "linked": [["@xata.io/client", "@xata.io/codegen"]],
   "access": "restricted",
   "baseBranch": "main",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        with:
-          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
-          fetch-depth: 0
-          # This makes the PR pushed to use GITHUB_TOKEN and trigger the checks
-          persist-credentials: false
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: |
@@ -45,8 +40,6 @@ jobs:
         uses: changesets/action@v1
         with:
           title: Release tracking
-          publish: npx lerna publish from-package --no-verify-access --yes
-          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Attempt to publish releases by using the default `publish` command
- Remove the options in checkout, I checked other repos and they don't include them

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
