### PR TITLE
Remove yarn usages

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -106,8 +106,8 @@
     "build": "shx rm -rf dist && tsc -b && cp src/*.html dist",
     "lint": "eslint . --ext .ts --config .eslintrc",
     "postpack": "shx rm -f oclif.manifest.json",
-    "posttest": "yarn lint",
-    "prepack": "yarn build && oclif manifest && oclif readme",
+    "posttest": "npm run lint",
+    "prepack": "npm run build && oclif manifest && oclif readme",
     "version": "oclif readme && git add README.md",
     "start": "node ./bin/run.js"
   },


### PR DESCRIPTION
Breaks if `yarn` is not installed globally