### PR TITLE
Treat branch names specified with third party env variables as git branches in the resolution algorithm

### DIFF
--- a/.changeset/healthy-elephants-agree.md
+++ b/.changeset/healthy-elephants-agree.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': minor
+---
+
+Treat branch name specified with third party env variables as git branches in the resolution algorithm

--- a/packages/client/src/util/config.ts
+++ b/packages/client/src/util/config.ts
@@ -12,7 +12,7 @@ type BranchResolutionOptions = {
 };
 
 export async function getCurrentBranchName(options?: BranchResolutionOptions): Promise<string> {
-  const { branch } = getEnvironment();
+  const { branch, envBranch } = getEnvironment();
 
   if (branch) {
     const details = await getDatabaseBranch(branch, options);
@@ -21,7 +21,7 @@ export async function getCurrentBranchName(options?: BranchResolutionOptions): P
     console.warn(`Branch ${branch} not found in Xata. Ignoring...`);
   }
 
-  const gitBranch = await getGitBranch();
+  const gitBranch = envBranch || (await getGitBranch());
   return resolveXataBranch(gitBranch, options);
 }
 

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -22,7 +22,7 @@ export function getEnvironment(): Environment {
       return {
         apiKey: process.env.XATA_API_KEY ?? getGlobalApiKey(),
         databaseURL: process.env.XATA_DATABASE_URL ?? getGlobalDatabaseURL(),
-        branch: process.env.XATA_BRANCH,
+        branch: process.env.XATA_BRANCH ?? getGlobalBranch(),
         envBranch: process.env.VERCEL_GIT_COMMIT_REF ?? process.env.CF_PAGES_BRANCH ?? process.env.BRANCH,
         fallbackBranch: process.env.XATA_FALLBACK_BRANCH ?? getGlobalFallbackBranch()
       };
@@ -37,7 +37,7 @@ export function getEnvironment(): Environment {
       return {
         apiKey: Deno.env.get('XATA_API_KEY') ?? getGlobalApiKey(),
         databaseURL: Deno.env.get('XATA_DATABASE_URL') ?? getGlobalDatabaseURL(),
-        branch: Deno.env.get('XATA_BRANCH'),
+        branch: Deno.env.get('XATA_BRANCH') ?? getGlobalBranch(),
         envBranch: Deno.env.get('VERCEL_GIT_COMMIT_REF') ?? Deno.env.get('CF_PAGES_BRANCH') ?? Deno.env.get('BRANCH'),
         fallbackBranch: Deno.env.get('XATA_FALLBACK_BRANCH') ?? getGlobalFallbackBranch()
       };

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -23,8 +23,7 @@ export function getEnvironment(): Environment {
         apiKey: process.env.XATA_API_KEY ?? getGlobalApiKey(),
         databaseURL: process.env.XATA_DATABASE_URL ?? getGlobalDatabaseURL(),
         branch: process.env.XATA_BRANCH,
-        envBranch:
-          process.env.VERCEL_GIT_COMMIT_REF ?? process.env.CF_PAGES_BRANCH ?? process.env.BRANCH ?? getGlobalBranch(),
+        envBranch: process.env.VERCEL_GIT_COMMIT_REF ?? process.env.CF_PAGES_BRANCH ?? process.env.BRANCH,
         fallbackBranch: process.env.XATA_FALLBACK_BRANCH ?? getGlobalFallbackBranch()
       };
     }
@@ -39,11 +38,7 @@ export function getEnvironment(): Environment {
         apiKey: Deno.env.get('XATA_API_KEY') ?? getGlobalApiKey(),
         databaseURL: Deno.env.get('XATA_DATABASE_URL') ?? getGlobalDatabaseURL(),
         branch: Deno.env.get('XATA_BRANCH'),
-        envBranch:
-          Deno.env.get('VERCEL_GIT_COMMIT_REF') ??
-          Deno.env.get('CF_PAGES_BRANCH') ??
-          Deno.env.get('BRANCH') ??
-          getGlobalBranch(),
+        envBranch: Deno.env.get('VERCEL_GIT_COMMIT_REF') ?? Deno.env.get('CF_PAGES_BRANCH') ?? Deno.env.get('BRANCH'),
         fallbackBranch: Deno.env.get('XATA_FALLBACK_BRANCH') ?? getGlobalFallbackBranch()
       };
     }

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -11,6 +11,7 @@ interface Environment {
   apiKey: string | undefined;
   databaseURL: string | undefined;
   branch: string | undefined;
+  envBranch: string | undefined;
   fallbackBranch: string | undefined;
 }
 
@@ -21,12 +22,9 @@ export function getEnvironment(): Environment {
       return {
         apiKey: process.env.XATA_API_KEY ?? getGlobalApiKey(),
         databaseURL: process.env.XATA_DATABASE_URL ?? getGlobalDatabaseURL(),
-        branch:
-          process.env.XATA_BRANCH ??
-          process.env.VERCEL_GIT_COMMIT_REF ??
-          process.env.CF_PAGES_BRANCH ??
-          process.env.BRANCH ??
-          getGlobalBranch(),
+        branch: process.env.XATA_BRANCH,
+        envBranch:
+          process.env.VERCEL_GIT_COMMIT_REF ?? process.env.CF_PAGES_BRANCH ?? process.env.BRANCH ?? getGlobalBranch(),
         fallbackBranch: process.env.XATA_FALLBACK_BRANCH ?? getGlobalFallbackBranch()
       };
     }
@@ -40,8 +38,8 @@ export function getEnvironment(): Environment {
       return {
         apiKey: Deno.env.get('XATA_API_KEY') ?? getGlobalApiKey(),
         databaseURL: Deno.env.get('XATA_DATABASE_URL') ?? getGlobalDatabaseURL(),
-        branch:
-          Deno.env.get('XATA_BRANCH') ??
+        branch: Deno.env.get('XATA_BRANCH'),
+        envBranch:
           Deno.env.get('VERCEL_GIT_COMMIT_REF') ??
           Deno.env.get('CF_PAGES_BRANCH') ??
           Deno.env.get('BRANCH') ??
@@ -57,6 +55,7 @@ export function getEnvironment(): Environment {
     apiKey: getGlobalApiKey(),
     databaseURL: getGlobalDatabaseURL(),
     branch: getGlobalBranch(),
+    envBranch: undefined,
     fallbackBranch: getGlobalFallbackBranch()
   };
 }


### PR DESCRIPTION
For example if a Vercel preview environment has `VERCEL_GIT_COMMIT_REF=foo`, we have to resolve `foo` to see if it exists, and if not, use the default branch.