### PR TITLE
Custom slugify

### DIFF
--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -9,12 +9,12 @@ import { readFile, writeFile } from 'fs/promises';
 import fetch from 'node-fetch';
 import path from 'path';
 import prompts from 'prompts';
-import slugify from 'slugify';
 import table from 'text-table';
 import which from 'which';
 import { z, ZodError } from 'zod';
 import { createAPIKeyThroughWebUI } from './auth-server.js';
 import { getProfile } from './credentials.js';
+import { slug } from './utils.js';
 
 export const projectConfigSchema = z.object({
   databaseURL: z.string(),
@@ -190,7 +190,7 @@ export abstract class BaseCommand extends Command {
         message: 'New workspace name'
       });
       if (!name) return this.error('No workspace name provided');
-      const workspace = await xata.workspaces.createWorkspace({ name, slug: slugify(name) });
+      const workspace = await xata.workspaces.createWorkspace({ name, slug: slug(name) });
       return workspace.id;
     } else if (workspaces.workspaces.length === 1) {
       const workspace = workspaces.workspaces[0].id;

--- a/cli/src/commands/workspaces/create.ts
+++ b/cli/src/commands/workspaces/create.ts
@@ -1,5 +1,5 @@
-import slugify from 'slugify';
 import { BaseCommand } from '../../base.js';
+import { slug } from '../../utils.js';
 
 export default class WorkspacesCreate extends BaseCommand {
   static description = 'Create a workspace';
@@ -24,7 +24,7 @@ export default class WorkspacesCreate extends BaseCommand {
 
     const xata = await this.getXataClient();
 
-    const result = await xata.workspaces.createWorkspace({ name: workspace, slug: slugify(workspace) });
+    const result = await xata.workspaces.createWorkspace({ name: workspace, slug: slug(workspace) });
 
     if (this.jsonEnabled()) return result;
 

--- a/cli/src/utils.test.ts
+++ b/cli/src/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { pluralize, slug } from './utils';
+
+describe('pluralize', () => {
+  test('pluralizes words', async () => {
+    expect(pluralize('foo', 0)).toEqual('foos');
+    expect(pluralize('foo', 1)).toEqual('foo');
+    expect(pluralize('foo', 2)).toEqual('foos');
+  });
+});
+
+describe('slug', () => {
+  test('slugs words', async () => {
+    expect(slug('1')).toEqual('1');
+    expect(slug('Acme')).toEqual('Acme');
+    expect(slug('Acme Inc')).toEqual('Acme-Inc');
+    expect(slug('Acme Inc.')).toEqual('Acme-Inc');
+  });
+
+  test('makes sure the slug is not empty and starts with alphanumeric', async () => {
+    expect(slug('')).toEqual('a');
+    expect(slug('~foo')).toEqual('a~foo');
+  });
+
+  test('replaces symbols', async () => {
+    expect(slug('<')).toEqual('less');
+  });
+});

--- a/cli/src/utils.ts
+++ b/cli/src/utils.ts
@@ -1,3 +1,12 @@
+import slugify from 'slugify';
+
 export function pluralize(word: string, count: number) {
   return `${word}${count === 1 ? '' : 's'}`;
+}
+
+// Based on `IsValidIdentifier` from xvalidator.go
+export function slug(name: string) {
+  const str = slugify(name, { remove: /[^a-zA-Z0-9-_~\s]/ });
+  if (str.charAt(0).match(/[a-zA-Z0-9]/)) return str;
+  return `a${str}`;
 }


### PR DESCRIPTION
A custom `slug` function that works with https://github.com/xataio/xata/blob/4397604f6b9b3a33551ebfb25d6cf5b27ec3e4dd/internal/xvalidator/xvalidator.go#L17

We'll probably need to do the same in the frontend.
An alternative would've been that the slug is optional and the backend generates a valid one if not provided.

Closes https://github.com/xataio/client-ts/issues/468