### PR TITLE
Allow injecting branch name in codegen

### DIFF
--- a/.changeset/three-dogs-teach.md
+++ b/.changeset/three-dogs-teach.md
@@ -1,0 +1,6 @@
+---
+'@xata.io/cli': minor
+'@xata.io/codegen': minor
+---
+
+Allow injecting the branch name in codegen

--- a/cli/src/commands/codegen/index.ts
+++ b/cli/src/commands/codegen/index.ts
@@ -27,6 +27,10 @@ export default class Codegen extends BaseCommand {
     declarations: Flags.boolean({
       description:
         'Whether or not the declarations file should be generated. Overwrites your project configuration setting'
+    }),
+    'inject-branch': Flags.boolean({
+      description:
+        'Inject the branch name into the generated code. Useful if you have a build step and the branch name is not available at runtime'
     })
   };
 
@@ -63,8 +67,14 @@ export default class Codegen extends BaseCommand {
     const branchDetails = await xata.branches.getBranchDetails(workspace, database, branch);
     const { schema } = branchDetails;
 
+    const codegenBranch = flags['inject-branch'] ? branch : undefined;
     // TODO: remove formatVersion
-    const result = await generate({ schema: { formatVersion: '1.0', ...schema }, databaseURL, language });
+    const result = await generate({
+      schema: { formatVersion: '1.0', ...schema },
+      databaseURL,
+      language,
+      branch: codegenBranch
+    });
     const code = result.transpiled;
     const declarations = result.declarations;
 

--- a/packages/codegen/example/xata.js
+++ b/packages/codegen/example/xata.js
@@ -34,9 +34,10 @@ const tables = [
 ];
 /** @type { import('../../client/src').ClientConstructor<{}> } */
 const DatabaseClient = buildClient();
+const defaultOptions = { databaseURL: 'https://test-r5vcv5.xata.sh/db/test' };
 /** @extends DatabaseClient<SchemaTables> */
 export class XataClient extends DatabaseClient {
   constructor(options) {
-    super({ databaseURL: 'https://test-r5vcv5.xata.sh/db/test', ...options }, tables);
+    super({ ...defaultOptions, ...options }, tables);
   }
 }

--- a/packages/codegen/example/xata.ts
+++ b/packages/codegen/example/xata.ts
@@ -43,8 +43,10 @@ export type UserRecord = User & XataRecord;
 
 const DatabaseClient = buildClient();
 
+const defaultOptions = { databaseURL: 'https://test-r5vcv5.xata.sh/db/test' };
+
 export class XataClient extends DatabaseClient<SchemaTables> {
   constructor(options?: BaseClientOptions) {
-    super({ databaseURL: 'https://test-r5vcv5.xata.sh/db/test', ...options }, tables);
+    super({ ...defaultOptions, ...options }, tables);
   }
 }

--- a/test/__snapshots__/codegen.test.ts.snap
+++ b/test/__snapshots__/codegen.test.ts.snap
@@ -1,5 +1,38 @@
 // Vitest Snapshot v1
 
+exports[`generate > should inject branch if passed 1`] = `
+"import {
+  BaseClientOptions,
+  buildClient,
+  SchemaInference,
+  XataRecord,
+} from \\"@xata.io/client\\";
+
+const tables = [
+  { name: \\"users\\", columns: [{ name: \\"name\\", type: \\"string\\" }] },
+] as const;
+
+export type SchemaTables = typeof tables;
+export type DatabaseSchema = SchemaInference<SchemaTables>;
+
+export type User = DatabaseSchema[\\"users\\"];
+export type UserRecord = User & XataRecord;
+
+const DatabaseClient = buildClient();
+
+const defaultOptions = {
+  databaseURL: \\"https://workspace-1234.xata.sh/db/dbname\\",
+  branch: \\"feature-branch\\",
+};
+
+export class XataClient extends DatabaseClient<SchemaTables> {
+  constructor(options?: BaseClientOptions) {
+    super({ ...defaultOptions, ...options }, tables);
+  }
+}
+"
+`;
+
 exports[`generate > should respect case naming 1`] = `
 "import {
   BaseClientOptions,
@@ -38,9 +71,13 @@ export type UsersFooRecord = UsersFoo & XataRecord;
 
 const DatabaseClient = buildClient();
 
+const defaultOptions = {
+  databaseURL: \\"https://workspace-1234.xata.sh/db/dbname\\",
+};
+
 export class XataClient extends DatabaseClient<SchemaTables> {
   constructor(options?: BaseClientOptions) {
-    super({ databaseURL: \\"\\", ...options }, tables);
+    super({ ...defaultOptions, ...options }, tables);
   }
 }
 "
@@ -72,9 +109,13 @@ export type $1teamsCaseRecord = $1teamsCase & XataRecord;
 
 const DatabaseClient = buildClient();
 
+const defaultOptions = {
+  databaseURL: \\"https://workspace-1234.xata.sh/db/dbname\\",
+};
+
 export class XataClient extends DatabaseClient<SchemaTables> {
   constructor(options?: BaseClientOptions) {
-    super({ databaseURL: \\"\\", ...options }, tables);
+    super({ ...defaultOptions, ...options }, tables);
   }
 }
 "

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -21,7 +21,7 @@ describe('generate', () => {
         ]
       },
       language: 'typescript',
-      databaseURL: ''
+      databaseURL: 'https://workspace-1234.xata.sh/db/dbname'
     });
 
     expect(output.transpiled).toMatchSnapshot();
@@ -51,7 +51,26 @@ describe('generate', () => {
         ]
       },
       language: 'typescript',
-      databaseURL: ''
+      databaseURL: 'https://workspace-1234.xata.sh/db/dbname'
+    });
+
+    expect(output.transpiled).toMatchSnapshot();
+  });
+
+  it('should inject branch if passed', async () => {
+    const output = await generate({
+      schema: {
+        formatVersion: '1.0',
+        tables: [
+          {
+            name: 'users',
+            columns: [{ name: 'name', type: 'string' }]
+          }
+        ]
+      },
+      language: 'typescript',
+      databaseURL: 'https://workspace-1234.xata.sh/db/dbname',
+      branch: 'feature-branch'
     });
 
     expect(output.transpiled).toMatchSnapshot();


### PR DESCRIPTION
In CLI:
`xata codegen --inject-branch`

Now if there's a build step users can do:

```
"build": "xata codegen --inject-branch && tsc ..."
```

In the codegen package there's a new `branch` option.