### PR TITLE
Remove clipboard support for interactive schema

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@xata.io/cli",
       "version": "0.6.0",
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^7.3.0",
         "@oclif/core": "^1.11.0",
@@ -22,7 +22,6 @@
         "ansi-regex": "^6.0.1",
         "chalk": "^5.0.1",
         "cli-highlight": "^2.1.11",
-        "clipboardy": "^3.0.0",
         "cosmiconfig": "^7.0.1",
         "deepmerge": "^4.2.2",
         "dotenv": "^16.0.1",
@@ -1751,25 +1750,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
       "dev": true,
@@ -2290,55 +2270,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/clipboardy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
-      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
-      "dependencies": {
-        "arch": "^2.2.0",
-        "execa": "^5.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/clipboardy/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "license": "ISC",
@@ -2643,6 +2574,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4409,6 +4341,7 @@
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -5192,6 +5125,7 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -5214,6 +5148,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5944,6 +5879,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -7286,6 +7222,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7296,6 +7233,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7339,6 +7277,7 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/sisteransi": {
@@ -7584,6 +7523,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9976,11 +9916,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ=="
-    },
     "are-we-there-yet": {
       "version": "2.0.0",
       "dev": true,
@@ -10300,39 +10235,6 @@
       "version": "3.0.0",
       "dev": true
     },
-    "clipboardy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
-      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
-      "requires": {
-        "arch": "^2.2.0",
-        "execa": "^5.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.0",
-            "human-signals": "^2.1.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.1",
-            "onetime": "^5.1.2",
-            "signal-exit": "^3.0.3",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
-        }
-      }
-    },
     "cliui": {
       "version": "7.0.4",
       "requires": {
@@ -10553,6 +10455,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
+      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -11718,7 +11621,8 @@
       }
     },
     "human-signals": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "humanize-ms": {
       "version": "1.2.1",
@@ -12228,7 +12132,8 @@
       }
     },
     "merge-stream": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "merge2": {
       "version": "1.4.1"
@@ -12241,7 +12146,8 @@
       }
     },
     "mimic-fn": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -12741,6 +12647,7 @@
     },
     "onetime": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -13605,12 +13512,14 @@
     },
     "shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.7.3",
@@ -13634,7 +13543,8 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.7"
+      "version": "3.0.7",
+      "dev": true
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -13793,7 +13703,8 @@
       "dev": true
     },
     "strip-final-newline": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,6 @@
     "ansi-regex": "^6.0.1",
     "chalk": "^5.0.1",
     "cli-highlight": "^2.1.11",
-    "clipboardy": "^3.0.0",
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
     "dotenv": "^16.0.1",

--- a/cli/src/commands/schema/edit.ts
+++ b/cli/src/commands/schema/edit.ts
@@ -1,16 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { Flags } from '@oclif/core';
 import { getBranchDetails, Schemas } from '@xata.io/client';
 import chalk from 'chalk';
-import clipboardy from 'clipboardy';
 import enquirer from 'enquirer';
-import { BaseCommand } from '../../base.js';
-import Codegen from '../codegen/index.js';
-import { defaultEditor, getEditor, allEditors } from 'env-editor';
-import { Flags } from '@oclif/core';
-import tmp from 'tmp';
+import { getEditor } from 'env-editor';
 import { readFile, writeFile } from 'fs/promises';
-import { parseSchemaFile } from '../../schema.js';
+import tmp from 'tmp';
 import which from 'which';
+import { BaseCommand } from '../../base.js';
+import { parseSchemaFile } from '../../schema.js';
+import Codegen from '../codegen/index.js';
 
 // The enquirer library has type definitions but they are very poor
 const { Select, Snippet, Confirm } = enquirer as any;
@@ -241,37 +240,7 @@ Beware that this can lead to ${chalk.bold(
     select.on('keypress', async (char: string, key: { name: string; action: string }) => {
       const flatChoice = flatChoices[select.state.index];
       try {
-        if (key.action === 'paste') {
-          if (!flatChoice) return;
-
-          if (flatChoice.name.type == 'schema') {
-            try {
-              const data = JSON.parse(clipboardy.readSync());
-              // TODO: validate that it's a table
-              data.added = true;
-              this.tables.push(data);
-              this.selectItem = data;
-            } catch (err) {
-              if (!(err instanceof SyntaxError)) throw err;
-            }
-          } else if (flatChoice.name.type === 'edit-table') {
-            const table = flatChoice.name.table;
-            try {
-              const data = JSON.parse(clipboardy.readSync());
-              // TODO: validate that it's a table
-              data.added = true;
-              table.columns.push(data);
-              this.selectItem = data;
-            } catch (err) {
-              if (!(err instanceof SyntaxError)) throw err;
-            }
-          } else {
-            return;
-          }
-
-          await select.cancel();
-          await this.showSchema();
-        } else if (key.name === 'backspace' || key.name === 'delete') {
+        if (key.name === 'backspace' || key.name === 'delete') {
           if (!flatChoice) return; // add table is not here for example
           const choice = flatChoice.name;
           if (typeof choice !== 'object') return;


### PR DESCRIPTION
This part was very experimental: pasting a chunk of JSON when a table or the schema section is selected, to be able to copy&paste in the interactive schema editor.

However this feature is hard to find and not very conventional.

Since we have now `xata schema edit --source`, I think this is no longer needed.