### PR TITLE
Remove cli highlight. Use basic styling

### DIFF
--- a/.changeset/old-readers-bow.md
+++ b/.changeset/old-readers-bow.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Remove code highlighting in xata init

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xata.io/cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xata.io/cli",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^7.3.0",
@@ -16,12 +16,11 @@
         "@oclif/plugin-plugins": "^2.1.0",
         "@types/ini": "^1.3.31",
         "@types/prompts": "^2.0.14",
-        "@xata.io/client": "^0.14.0",
-        "@xata.io/codegen": "^0.14.0",
-        "@xata.io/importer": "^0.2.3",
+        "@xata.io/client": "^0.15.0",
+        "@xata.io/codegen": "^0.15.0",
+        "@xata.io/importer": "^0.2.4",
         "ansi-regex": "^6.0.1",
         "chalk": "^5.0.1",
-        "cli-highlight": "^2.1.11",
         "cosmiconfig": "^7.0.1",
         "deepmerge": "^4.2.2",
         "dotenv": "^16.0.1",
@@ -1558,31 +1557,30 @@
       }
     },
     "node_modules/@xata.io/client": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.14.0.tgz",
-      "integrity": "sha512-SKte+A4CL9rwONHY3x/hgSvdymdBKN4CvyfT4umOaKNQ1XRGrgm775PIXCj2DRizRxoIeHoTsK4rUbeBCNG81g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.15.0.tgz",
+      "integrity": "sha512-obQKxbQCXovoxTOHwwfZR5We3eXCMxKc1DmY5+2VR3m0Jai6YPjouZne8f8u00MXe9pyJWT+E0wQdeFVqii3tQ==",
       "peerDependencies": {
         "typescript": ">=4.5"
       }
     },
     "node_modules/@xata.io/codegen": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/codegen/-/codegen-0.14.0.tgz",
-      "integrity": "sha512-mDRMkdZKnoSxzeVsFv2kX6/MXbCxBwF5+Bk42G7eXm6T7NdVxPCac8wJ8r/5BHzMq6UVrYmEubpqVnZ8GGxsEw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/codegen/-/codegen-0.15.0.tgz",
+      "integrity": "sha512-lqbQ8IMQCYRWOc2i7U1hFi+aASp2wmf5Th1WuJGNe/dAb56NVo3i3iTz4uDaGR4SqTsat9ky29Q6A8dVafvIbA==",
       "dependencies": {
         "case": "^1.6.3",
-        "pluralize": "^8.0.0",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
-        "zod": "^3.17.9"
+        "zod": "^3.17.10"
       }
     },
     "node_modules/@xata.io/importer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.3.tgz",
-      "integrity": "sha512-eDZnE599MdOFfkKzl9WL/rdqG71AOLRLth6lKbYS5VberfLhhH32qeNhZ8icjh5ObDbc5d8AXq/IlBA/eFeImQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.4.tgz",
+      "integrity": "sha512-lzpODaJdfsrbXNHspQ17wHoLkhWB2tnL/cblkC4z8yPK2Y6QX1XwfUDvoCK3XBDnO59GAC9xJq9wmvbXEuDelg==",
       "dependencies": {
-        "@xata.io/client": "^0.14.0",
+        "@xata.io/client": "^0.15.0",
         "camelcase": "^7.0.0",
         "csvtojson": "^2.0.10",
         "transliteration": "^2.3.5"
@@ -1730,11 +1728,6 @@
     "node_modules/ansicolors": {
       "version": "0.3.2",
       "license": "MIT"
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/aproba": {
       "version": "2.0.0",
@@ -2171,52 +2164,6 @@
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "bin": {
-        "highlight": "bin/highlight"
-      },
-      "engines": {
-        "node": ">=8.0.0",
-        "npm": ">=5.0.0"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/cli-highlight/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -4241,14 +4188,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -5296,16 +5235,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -5764,6 +5693,7 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6127,24 +6057,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "dependencies": {
-        "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-    },
     "node_modules/password-prompt": {
       "version": "1.1.2",
       "license": "WTFPL",
@@ -6332,6 +6244,7 @@
     },
     "node_modules/pluralize": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7668,25 +7581,6 @@
         "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/through": {
       "version": "2.3.8",
       "dev": true,
@@ -8215,31 +8109,6 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/yarn": {
@@ -9759,29 +9628,28 @@
       }
     },
     "@xata.io/client": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.14.0.tgz",
-      "integrity": "sha512-SKte+A4CL9rwONHY3x/hgSvdymdBKN4CvyfT4umOaKNQ1XRGrgm775PIXCj2DRizRxoIeHoTsK4rUbeBCNG81g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.15.0.tgz",
+      "integrity": "sha512-obQKxbQCXovoxTOHwwfZR5We3eXCMxKc1DmY5+2VR3m0Jai6YPjouZne8f8u00MXe9pyJWT+E0wQdeFVqii3tQ==",
       "requires": {}
     },
     "@xata.io/codegen": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/codegen/-/codegen-0.14.0.tgz",
-      "integrity": "sha512-mDRMkdZKnoSxzeVsFv2kX6/MXbCxBwF5+Bk42G7eXm6T7NdVxPCac8wJ8r/5BHzMq6UVrYmEubpqVnZ8GGxsEw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/codegen/-/codegen-0.15.0.tgz",
+      "integrity": "sha512-lqbQ8IMQCYRWOc2i7U1hFi+aASp2wmf5Th1WuJGNe/dAb56NVo3i3iTz4uDaGR4SqTsat9ky29Q6A8dVafvIbA==",
       "requires": {
         "case": "^1.6.3",
-        "pluralize": "^8.0.0",
         "prettier": "^2.7.1",
         "typescript": "^4.7.4",
-        "zod": "^3.17.9"
+        "zod": "^3.17.10"
       }
     },
     "@xata.io/importer": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.3.tgz",
-      "integrity": "sha512-eDZnE599MdOFfkKzl9WL/rdqG71AOLRLth6lKbYS5VberfLhhH32qeNhZ8icjh5ObDbc5d8AXq/IlBA/eFeImQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.4.tgz",
+      "integrity": "sha512-lzpODaJdfsrbXNHspQ17wHoLkhWB2tnL/cblkC4z8yPK2Y6QX1XwfUDvoCK3XBDnO59GAC9xJq9wmvbXEuDelg==",
       "requires": {
-        "@xata.io/client": "^0.14.0",
+        "@xata.io/client": "^0.15.0",
         "camelcase": "^7.0.0",
         "csvtojson": "^2.0.10",
         "transliteration": "^2.3.5"
@@ -9874,11 +9742,6 @@
     },
     "ansicolors": {
       "version": "0.3.2"
-    },
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "aproba": {
       "version": "2.0.0",
@@ -10148,38 +10011,6 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
-      }
-    },
-    "cli-highlight": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
-      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
-      "requires": {
-        "chalk": "^4.0.0",
-        "highlight.js": "^10.7.1",
-        "mz": "^2.4.0",
-        "parse5": "^5.1.1",
-        "parse5-htmlparser2-tree-adapter": "^6.0.0",
-        "yargs": "^16.0.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "cli-progress": {
@@ -11528,11 +11359,6 @@
       "version": "2.0.1",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
-    },
     "hosted-git-info": {
       "version": "4.1.0",
       "dev": true,
@@ -12217,16 +12043,6 @@
       "version": "0.0.8",
       "dev": true
     },
-    "mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "requires": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "natural-compare": {
       "version": "1.4.0",
       "dev": true
@@ -12540,7 +12356,8 @@
       "dev": true
     },
     "object-assign": {
-      "version": "4.1.1"
+      "version": "4.1.1",
+      "dev": true
     },
     "object-treeify": {
       "version": "1.1.33"
@@ -12783,26 +12600,6 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
-    "parse5": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
-      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
-    },
-    "parse5-htmlparser2-tree-adapter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
-      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
-      "requires": {
-        "parse5": "^6.0.1"
-      },
-      "dependencies": {
-        "parse5": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-          "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
-        }
-      }
-    },
     "password-prompt": {
       "version": "1.1.2",
       "requires": {
@@ -12912,7 +12709,8 @@
       }
     },
     "pluralize": {
-      "version": "8.0.0"
+      "version": "8.0.0",
+      "dev": true
     },
     "preferred-pm": {
       "version": "3.0.3",
@@ -13781,22 +13579,6 @@
       "version": "5.15.0",
       "dev": true
     },
-    "thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "requires": {
-        "thenify": ">= 3.1.0 < 4"
-      }
-    },
     "through": {
       "version": "2.3.8",
       "dev": true
@@ -14161,25 +13943,6 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     },
     "yarn": {
       "version": "1.22.18"

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,6 @@
     "@xata.io/importer": "^0.2.4",
     "ansi-regex": "^6.0.1",
     "chalk": "^5.0.1",
-    "cli-highlight": "^2.1.11",
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
     "dotenv": "^16.0.1",

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -1,6 +1,5 @@
 import { Flags } from '@oclif/core';
 import chalk from 'chalk';
-import { highlight } from 'cli-highlight';
 import { access, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import which from 'which';
@@ -112,10 +111,10 @@ export default class Init extends BaseCommand {
     this.printCode([
       "import { XataApiClient } from '@xata.io/client';",
       '',
-      '// Initialize the client',
+      chalk.dim('// Initialize the client'),
       'const api = new XataApiClient();',
       '',
-      '// Usage example',
+      chalk.dim('// Usage example'),
       "const record = await client.records.getRecord(workspace, databaseName, 'branch', 'table', recordId);"
     ]);
 
@@ -140,14 +139,14 @@ export default class Init extends BaseCommand {
       'Do you want to use the code generator? The code generator will allow you to use your database with type safety and autocompletion. Example:'
     );
     this.printCode([
-      '// Import the generated code',
-      "import { XataClient } from './xata';",
+      chalk.dim('// Import the generated code'),
+      `import { XataClient } from './xata';`,
       '',
-      '// Initialize the client',
+      chalk.dim('// Initialize the client'),
       'const xata = new XataClient();',
       '',
-      '// Query a table with a simple filter',
-      'const { records } = await xata.db.tableName.filter("column", value).getPaginated();'
+      chalk.dim('// Query a table with a simple filter'),
+      'const { records } = await xata.db.TableName.filter("column", value).getPaginated();'
     ]);
 
     const { flags } = await this.parse(Init);
@@ -197,10 +196,10 @@ export default class Init extends BaseCommand {
   }
 
   printCode(lines: string[]) {
-    const code = lines.map((line) => `\t${line}`).join('\n');
-    const highlighted = highlight(code, { language: 'typescript' });
     this.log();
-    this.log(highlighted);
+    for (const line of lines) {
+      this.log('\t', line);
+    }
     this.log();
   }
 


### PR DESCRIPTION
Depending on the colors of the terminal, the highlighting can be hard to read, and there's no easy way to detect the background color of the terminal. So, in this PR, I remove the highlighting and I just use `chalk.dim()` in code comments:

Before and after:

<img width="757" alt="image" src="https://user-images.githubusercontent.com/50486/181642206-f29bf4a2-ac11-47e4-898a-1ee96cdd73d7.png">