### PR TITLE
Fix shell timeout

### DIFF
--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { Errors, flush, run } from '@oclif/core';
+import { Errors, run } from '@oclif/core';
 
 run(void 0, import.meta.url)
-  .then(flush)
+  // .then(flush) // Prevent timeout in xata shell
   .catch(Errors.handle);


### PR DESCRIPTION
Closes https://github.com/xataio/client-ts/issues/477

`flush` generates an error [when process.stdout sends a `drain` event](https://github.com/oclif/core/blob/f759fb1710eb1013a48fa04e817d43231553590a/src/cli-ux/index.ts#L13-L30), and I believe the Nodejs repl sends that event.