### PR TITLE
Do not encrypt app info

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xata.io/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xata.io/cli",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@faker-js/faker": "^7.3.0",
@@ -16,9 +16,9 @@
         "@oclif/plugin-plugins": "^2.1.0",
         "@types/ini": "^1.3.31",
         "@types/prompts": "^2.0.14",
-        "@xata.io/client": "^0.15.0",
+        "@xata.io/client": "^0.16.0",
         "@xata.io/codegen": "^0.15.0",
-        "@xata.io/importer": "^0.2.4",
+        "@xata.io/importer": "^0.2.5",
         "ansi-regex": "^6.0.1",
         "chalk": "^5.0.1",
         "cosmiconfig": "^7.0.1",
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@xata.io/client": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.15.0.tgz",
-      "integrity": "sha512-obQKxbQCXovoxTOHwwfZR5We3eXCMxKc1DmY5+2VR3m0Jai6YPjouZne8f8u00MXe9pyJWT+E0wQdeFVqii3tQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.16.0.tgz",
+      "integrity": "sha512-yt/9pecSr0wNbUoCs/rlw0NsSBnw8r6mRGjh6P+YrPW24uNw88HVXIrqbP57PWXplL7UL6fBFjNay55eEO7qrA==",
       "peerDependencies": {
         "typescript": ">=4.5"
       }
@@ -1576,11 +1576,11 @@
       }
     },
     "node_modules/@xata.io/importer": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.4.tgz",
-      "integrity": "sha512-lzpODaJdfsrbXNHspQ17wHoLkhWB2tnL/cblkC4z8yPK2Y6QX1XwfUDvoCK3XBDnO59GAC9xJq9wmvbXEuDelg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.5.tgz",
+      "integrity": "sha512-TN3+6NoVPw6jfG2/ID8LBulSCffXVltoAlCsd3AVnP90tlSEQtNqM9zvId/f8UvwbVwOWAuQdiLXAdXPwoASBg==",
       "dependencies": {
-        "@xata.io/client": "^0.15.0",
+        "@xata.io/client": "^0.16.0",
         "camelcase": "^7.0.0",
         "csvtojson": "^2.0.10",
         "transliteration": "^2.3.5"
@@ -9628,9 +9628,9 @@
       }
     },
     "@xata.io/client": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.15.0.tgz",
-      "integrity": "sha512-obQKxbQCXovoxTOHwwfZR5We3eXCMxKc1DmY5+2VR3m0Jai6YPjouZne8f8u00MXe9pyJWT+E0wQdeFVqii3tQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.16.0.tgz",
+      "integrity": "sha512-yt/9pecSr0wNbUoCs/rlw0NsSBnw8r6mRGjh6P+YrPW24uNw88HVXIrqbP57PWXplL7UL6fBFjNay55eEO7qrA==",
       "requires": {}
     },
     "@xata.io/codegen": {
@@ -9645,11 +9645,11 @@
       }
     },
     "@xata.io/importer": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.4.tgz",
-      "integrity": "sha512-lzpODaJdfsrbXNHspQ17wHoLkhWB2tnL/cblkC4z8yPK2Y6QX1XwfUDvoCK3XBDnO59GAC9xJq9wmvbXEuDelg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@xata.io/importer/-/importer-0.2.5.tgz",
+      "integrity": "sha512-TN3+6NoVPw6jfG2/ID8LBulSCffXVltoAlCsd3AVnP90tlSEQtNqM9zvId/f8UvwbVwOWAuQdiLXAdXPwoASBg==",
       "requires": {
-        "@xata.io/client": "^0.15.0",
+        "@xata.io/client": "^0.16.0",
         "camelcase": "^7.0.0",
         "csvtojson": "^2.0.10",
         "transliteration": "^2.3.5"

--- a/cli/src/auth-server.test.ts
+++ b/cli/src/auth-server.test.ts
@@ -9,26 +9,16 @@ const { publicKey, privateKey, passphrase } = generateKeys();
 
 describe('generateURL', () => {
   test('generates a URL', async () => {
-    const uiURL = generateURL(port, publicKey, privateKey, passphrase);
+    const uiURL = generateURL(port, publicKey);
 
     expect(uiURL.startsWith('https://app.xata.io/new-api-key?')).toBe(true);
 
     const parsed = url.parse(uiURL, true);
-    const { pub, info } = parsed.query;
+    const { pub, name, redirect } = parsed.query;
 
-    const pk = crypto.createPublicKey(
-      `-----BEGIN PUBLIC KEY-----\n${String(pub).replace(/ /g, '+')}\n-----END PUBLIC KEY-----`
-    );
-    const appInfo = JSON.parse(
-      crypto.publicDecrypt(pk, Buffer.from(String(info).replace(/ /g, '+'), 'base64')).toString('utf-8')
-    );
-
-    expect(appInfo).toMatchInlineSnapshot(`
-      {
-        "name": "Xata CLI",
-        "redirect": "http://localhost:1234",
-      }
-    `);
+    expect(pub).toBeDefined();
+    expect(name).toEqual('Xata CLI');
+    expect(redirect).toEqual('http://localhost:1234');
   });
 });
 


### PR DESCRIPTION
The goal was to prevent users changing the parameters, but it's not a big deal. Also, we support also not encrypting them because the vscode extension uses web-crypto that does not allow encrypting with a private key.

This will also allow us to simplify the page in the frontend to not use `getServerSideProps`.