### PR TITLE
Do not deprecate ApiClient

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -16,9 +16,6 @@ export interface XataApiClientOptions {
   trace?: TraceFunction;
 }
 
-/**
- * @deprecated Use XataApiPlugin instead
- */
 export class XataApiClient {
   #extraProps: FetcherExtraProps;
   #namespaces: Partial<{


### PR DESCRIPTION
It's internal and we should promote plugins but definitely not going anywhere.

<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->
