### PR TITLE
Fix CLI on Windows: fork Node.js process to pass custom NODE_OPTIONS

### DIFF
--- a/.changeset/cool-apricots-hang.md
+++ b/.changeset/cool-apricots-hang.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fixed CLI on Windows

--- a/cli/bin/run-oclif.js
+++ b/cli/bin/run-oclif.js
@@ -1,0 +1,5 @@
+import { Errors, run } from '@oclif/core';
+
+run(void 0, import.meta.url)
+  // .then(flush) // Prevent timeout in xata shell
+  .catch(Errors.handle);

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -7,8 +7,11 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-fork(join(__dirname, 'run-oclif.js'), {
+const args = process.argv.slice(2);
+
+fork(join(__dirname, 'run-oclif.js'), args, {
   env: {
+    ...process.env,
     NODE_OPTIONS: '--experimental-vm-modules'
   }
 });

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -1,6 +1,14 @@
-#!/usr/bin/env -S NODE_OPTIONS=--experimental-vm-modules node
-import { Errors, run } from '@oclif/core';
+#!/usr/bin/env node
 
-run(void 0, import.meta.url)
-  // .then(flush) // Prevent timeout in xata shell
-  .catch(Errors.handle);
+import { fork } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+fork(join(__dirname, 'run-oclif.js'), {
+  env: {
+    NODE_OPTIONS: '--experimental-vm-modules'
+  }
+});

--- a/cli/bin/run.js
+++ b/cli/bin/run.js
@@ -12,6 +12,6 @@ const args = process.argv.slice(2);
 fork(join(__dirname, 'run-oclif.js'), args, {
   env: {
     ...process.env,
-    NODE_OPTIONS: '--experimental-vm-modules'
+    NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --experimental-vm-modules`
   }
 });


### PR DESCRIPTION
`#!/usr/bin/env -S ...` doesn't work on Windows, and we need a way to pass custom `NODE_OPTIONS`.

With this PR we create a fork of the Node.js process and we pass the `NODE_OPTIONS` that we want, keeping a simple shebang that should work on any platform.

Things I've tested:
- running directly works
- interactivity works
- running with npx works
- args work
- other env variables passed to the main process are passed to the child process as well