### PR TITLE
Make importer to be called programmatically

### DIFF
--- a/.changeset/bright-spiders-buy.md
+++ b/.changeset/bright-spiders-buy.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/importer': patch
+---
+
+Importer: Export parseCSVString

--- a/packages/importer/src/csv.ts
+++ b/packages/importer/src/csv.ts
@@ -15,7 +15,7 @@ export async function parseStream(stream: internal.Readable, options: ParseOptio
   return process(initConverter(options).fromStream(stream), options);
 }
 
-function initConverter({ noheader, delimiter }: ParseOptions) {
+function initConverter({ noheader = false, delimiter = [','] }: ParseOptions) {
   return csv({ output: 'csv', noheader, delimiter });
 }
 
@@ -49,7 +49,10 @@ function process(converter: Converter, { callback, batchSize = 1000, columns, ma
           converter.end();
         }
       },
-      reject,
+      (error) => {
+        console.error(error);
+        reject(error);
+      },
       () => {
         if (stopped) return;
         const p = lines.length > 0 ? callback(lines, columns, rows) : Promise.resolve();

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -12,6 +12,6 @@ export type ParseOptions = {
   callback: (lines: string[][], columns: string[] | undefined, count: number) => Promise<boolean | void>;
 };
 
-export { parseFile as parseCSVFile, parseStream as parseCSVStream } from './csv';
+export { parseFile as parseCSVFile, parseStream as parseCSVStream, parseString as parseCSVString } from './csv';
 export { createProcessor } from './processor';
 export type { CompareSchemaResult, TableInfo } from './processor';

--- a/packages/importer/src/processor.ts
+++ b/packages/importer/src/processor.ts
@@ -141,6 +141,7 @@ export async function updateSchema(xata: XataApiClient, tableInfo: TableInfo, ch
   }
 
   for (const column of changes.missingColumns) {
+    if (column.column === 'id') continue;
     await xata.tables.addTableColumn(workspaceID, database, branch, tableName, {
       name: column.column,
       type: column.type as Schemas.Column['type']


### PR DESCRIPTION
- Export `parseCSVString`
- Add default values for optional parameters (was erroring out internally)
- Do not attempt to create "id" column when no table exists