### PR TITLE
Add comments to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,21 +7,33 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
+
+<!--
 Steps to reproduce the behavior.
 
 - If this is a problem with an npm package, please provide a code snippet and a stacktrace if possible.
 - If this is a problem with the CLI, please provide the command(s) you are using and the output.
+ -->
 
 **Expected behavior**
+
+<!--
 A clear and concise description of what you expected to happen.
+-->
 
 **Software version**
 
+<!--
 - If this is a problem with an npm package, provide the version you are using in `package.json`.
 - If this is a problem with the CLI, provide the output you get with `xata --version`.
+-->
 
 **Additional context**
+
+<!--
 Add any other context about the problem here.
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,25 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
+
+<!--
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+-->
 
 **Describe the solution you'd like**
+
+<!--
 A clear and concise description of what you want to happen.
+-->
 
 **Describe alternatives you've considered**
+
+<!--
 A clear and concise description of any alternative solutions or features you've considered.
+-->
 
 **Additional context**
+
+<!--
 Add any other context or screenshots about the feature request here.
+-->


### PR DESCRIPTION
People forget to remove the placeholder text and it's a bit annoying. Putting it in comments so it's visible when editing the issue description but not visible when the issue is rendered.