### PR TITLE
Add back build + link step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        
+      - name: Compile
+        run: npm run build
+
+      - name: Link projects
+        run: npx lerna bootstrap --ci
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1


### PR DESCRIPTION
I hoped to leave the build to `changesets` but still doesn't work properly with 3 nested dependencies. If I change client, which is a dependency of importer, which is a dependency of cli, I need to run the release 3 times so it doesn't fail...