### PR TITLE
OpenAPI codegen from xata repository

### DIFF
--- a/openapi-codegen.config.ts
+++ b/openapi-codegen.config.ts
@@ -8,8 +8,8 @@ export default defineConfig({
       source: 'github',
       owner: 'xataio',
       ref: 'main',
-      repository: 'openapi',
-      specPath: 'bundled/openapi.yaml'
+      repository: 'xata',
+      specPath: 'openapi/bundled/openapi.yaml'
     },
     outputDir: 'packages/client/src/api',
     to: async (context) => {


### PR DESCRIPTION
We are moving the OpenAPI to the xata repository to reduce overhead during development and ensure that we have the APIs implemented when merging to main.

See: https://github.com/xataio/xata/pull/1090