### PR TITLE
[tracing] Propagate TraceID to the backend. Create a new setupEnv span. Fix span hierarchy

### DIFF
--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -429,10 +429,13 @@ export class RestRepository<Record extends XataRecord>
     const trace = options.pluginOptions.trace ?? defaultTrace;
     this.#trace = async <T>(
       name: string,
-      fn: (options: { setAttributes: (attrs: AttributeDictionary) => void }) => T,
+      fn: (options: {
+        setAttributes: (attrs: AttributeDictionary) => void;
+        propagateTrace: (headers: AttributeDictionary) => void;
+      }) => T,
       options: AttributeDictionary = {}
     ) => {
-      return trace<T>(name, fn, {
+      return trace<T>('sdk op: ' + name, fn, {
         ...options,
         [TraceAttributes.TABLE]: this.#table,
         [TraceAttributes.KIND]: 'sdk-operation',

--- a/packages/client/src/schema/tracing.ts
+++ b/packages/client/src/schema/tracing.ts
@@ -2,17 +2,26 @@ export type AttributeDictionary = Record<string, string | number | boolean | und
 
 export type TraceFunction = <T>(
   name: string,
-  fn: (options: { setAttributes: (attrs: AttributeDictionary) => void }) => T,
+  fn: (options: {
+    setAttributes: (attrs: AttributeDictionary) => void;
+    propagateTrace: (headers: Record<string, any>) => void;
+  }) => T,
   options?: AttributeDictionary
 ) => Promise<T>;
 
 export const defaultTrace: TraceFunction = async <T>(
   _name: string,
-  fn: (options: { setAttributes: (attrs: Record<string, string | number | boolean | undefined>) => void }) => T,
+  fn: (options: {
+    setAttributes: (attrs: AttributeDictionary) => void;
+    propagateTrace: (headers: Record<string, any>) => void;
+  }) => T,
   _options?: Record<string, any>
 ): Promise<T> => {
   return await fn({
     setAttributes: () => {
+      return;
+    },
+    propagateTrace: () => {
       return;
     }
   });


### PR DESCRIPTION
This PR tackles three main issues:
* *Propagate TraceID to the backend:* this change enables Datadog APM to link the SDK traces with the backend traces and logs
* *Use a dedicated `span` for the setup actions:* this change traces the setup actions performed by every `test suite` and links the `setup span` to the `suite span`

TODO:
- [ ] *Fix span hierarchy:* Actions performed inside each `test case` are linked to the `suite span` instead of the `test span`. The test span created in the `beforeEach` hook needs to be activated before the test code runs.
