### PR TITLE
Use multiple env files

### DIFF
--- a/.changeset/wet-wombats-nail.md
+++ b/.changeset/wet-wombats-nail.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Use .env.local if it exists for storing env vars during xata init. Load .env.local and .env always in the CLI.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -33,6 +33,7 @@
         "cosmiconfig": "^7.0.1",
         "deepmerge": "^4.2.2",
         "dotenv": "^16.0.2",
+        "dotenv-expand": "^9.0.0",
         "edge-runtime": "^1.1.0-beta.31",
         "enquirer": "^2.3.6",
         "env-editor": "^1.1.0",
@@ -8383,6 +8384,14 @@
       "version": "16.0.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
       "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-9.0.0.tgz",
+      "integrity": "sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==",
       "engines": {
         "node": ">=12"
       }
@@ -22382,6 +22391,11 @@
       "version": "16.0.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.2.tgz",
       "integrity": "sha512-JvpYKUmzQhYoIFgK2MOnF3bciIZoItIIoryihy0rIA+H4Jy0FmgyKYAHCTN98P5ybGSJcIFbh6QKeJdtZd1qhA=="
+    },
+    "dotenv-expand": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-9.0.0.tgz",
+      "integrity": "sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw=="
     },
     "edge-runtime": {
       "version": "1.1.0-beta.31",

--- a/cli/package.json
+++ b/cli/package.json
@@ -43,6 +43,7 @@
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
     "dotenv": "^16.0.2",
+    "dotenv-expand": "^9.0.0",
     "edge-runtime": "^1.1.0-beta.31",
     "enquirer": "^2.3.6",
     "env-editor": "^1.1.0",

--- a/cli/src/base.test.ts
+++ b/cli/src/base.test.ts
@@ -1,0 +1,129 @@
+import { Config } from '@oclif/core';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { BaseCommand } from './base.js';
+import dotenv from 'dotenv';
+import { clearEnvVariables } from './commands/utils.test.js';
+
+vi.mock('dotenv');
+
+class FakeCommand extends BaseCommand {
+  async run() {
+    // do nothing
+  }
+}
+
+beforeEach(() => {
+  clearEnvVariables();
+});
+
+describe('init', () => {
+  test('loads env files in the desired order', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation(() => ({
+      parsed: {}
+    }));
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toBeUndefined();
+    expect(command.apiKeyDotenvLocation).toEqual('');
+  });
+  test('works if the files do not exist', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation(() => ({
+      parsed: undefined
+    }));
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toBeUndefined();
+    expect(command.apiKeyDotenvLocation).toEqual('');
+  });
+
+  test('loads env variables from process.env if available', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation(() => ({
+      parsed: {
+        XATA_API_KEY: 'override'
+      }
+    }));
+    process.env.XATA_API_KEY = 'key';
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toEqual('shell');
+    expect(command.apiKeyDotenvLocation).toEqual('');
+  });
+
+  test('loads env variables from env files', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation(() => ({
+      parsed: {
+        XATA_API_KEY: 'key'
+      }
+    }));
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toEqual('dotenv');
+    expect(command.apiKeyDotenvLocation).toEqual('.env.local');
+  });
+
+  test('does not override env variables from previous env files', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation((options) => {
+      return {
+        parsed: {
+          XATA_API_KEY: options?.path === '.env.local' ? 'key' : 'override'
+        }
+      };
+    });
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toEqual('dotenv');
+    expect(command.apiKeyDotenvLocation).toEqual('.env.local');
+  });
+
+  test('sets env variables if previous env files did not contain them', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation((options) => {
+      return options?.path === '.env'
+        ? {
+            parsed: {
+              XATA_API_KEY: 'key'
+            }
+          }
+        : {};
+    });
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toEqual('dotenv');
+    expect(command.apiKeyDotenvLocation).toEqual('.env');
+  });
+});

--- a/cli/src/base.test.ts
+++ b/cli/src/base.test.ts
@@ -138,4 +138,25 @@ describe('init', () => {
 
     expect(process.env.XATA_API_KEY).toEqual('key');
   });
+
+  test('performs variable expansions', async () => {
+    const config = await Config.load();
+    const command = new FakeCommand([], config as Config);
+    const dotenvConfig = vi.spyOn(dotenv, 'config').mockImplementation(() => ({
+      parsed: {
+        FOO: 'key',
+        XATA_API_KEY: '${FOO}'
+      }
+    }));
+
+    await command.init();
+
+    expect(dotenvConfig).toHaveBeenNthCalledWith(1, { path: '.env.local' });
+    expect(dotenvConfig).toHaveBeenNthCalledWith(2, { path: '.env' });
+
+    expect(command.apiKeyLocation).toEqual('dotenv');
+    expect(command.apiKeyDotenvLocation).toEqual('.env.local');
+
+    expect(process.env.XATA_API_KEY).toEqual('key');
+  });
 });

--- a/cli/src/base.test.ts
+++ b/cli/src/base.test.ts
@@ -31,6 +31,8 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toBeUndefined();
     expect(command.apiKeyDotenvLocation).toEqual('');
+
+    expect(process.env.XATA_API_KEY).toBeUndefined();
   });
   test('works if the files do not exist', async () => {
     const config = await Config.load();
@@ -46,6 +48,8 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toBeUndefined();
     expect(command.apiKeyDotenvLocation).toEqual('');
+
+    expect(process.env.XATA_API_KEY).toBeUndefined();
   });
 
   test('loads env variables from process.env if available', async () => {
@@ -65,6 +69,8 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toEqual('shell');
     expect(command.apiKeyDotenvLocation).toEqual('');
+
+    expect(process.env.XATA_API_KEY).toEqual('key');
   });
 
   test('loads env variables from env files', async () => {
@@ -83,6 +89,8 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toEqual('dotenv');
     expect(command.apiKeyDotenvLocation).toEqual('.env.local');
+
+    expect(process.env.XATA_API_KEY).toEqual('key');
   });
 
   test('does not override env variables from previous env files', async () => {
@@ -103,6 +111,8 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toEqual('dotenv');
     expect(command.apiKeyDotenvLocation).toEqual('.env.local');
+
+    expect(process.env.XATA_API_KEY).toEqual('key');
   });
 
   test('sets env variables if previous env files did not contain them', async () => {
@@ -125,5 +135,7 @@ describe('init', () => {
 
     expect(command.apiKeyLocation).toEqual('dotenv');
     expect(command.apiKeyDotenvLocation).toEqual('.env');
+
+    expect(process.env.XATA_API_KEY).toEqual('key');
   });
 });

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -104,9 +104,10 @@ export abstract class BaseCommand extends Command {
   }
 
   loadEnvFile(path: string) {
+    const apiKey = process.env.XATA_API_KEY;
     let env = dotenv.config({ path });
     env = dotenvExpand.expand(env);
-    if (!this.apiKeyDotenvLocation && env.parsed?.['XATA_API_KEY']) {
+    if (!apiKey && env.parsed?.['XATA_API_KEY']) {
       this.apiKeyLocation = 'dotenv';
       this.apiKeyDotenvLocation = path;
     }

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -42,8 +42,8 @@ export abstract class BaseCommand extends Command {
   projectConfig?: ProjectConfig;
   projectConfigLocation?: string;
 
-  dotenvLocation = '.env';
   apiKeyLocation?: APIKeyLocation;
+  apiKeyDotenvLocation = '';
 
   #xataClient?: XataApiClient;
 
@@ -100,10 +100,18 @@ export abstract class BaseCommand extends Command {
     };
   }
 
+  loadEnvFile(path: string) {
+    const env = dotenv.config({ path });
+    if (env.parsed?.['XATA_API_KEY']) {
+      this.apiKeyLocation = 'dotenv';
+      this.apiKeyDotenvLocation = path;
+    }
+  }
+
   async init() {
     if (process.env.XATA_API_KEY) this.apiKeyLocation = 'shell';
-    const env = dotenv.config({ path: this.dotenvLocation });
-    if (env.parsed?.['XATA_API_KEY']) this.apiKeyLocation = 'dotenv';
+    this.loadEnvFile('.env.local');
+    this.loadEnvFile('.env');
 
     const moduleName = 'xata';
     const search = cosmiconfigSync(moduleName, { searchPlaces: this.searchPlaces }).search();
@@ -132,9 +140,9 @@ export abstract class BaseCommand extends Command {
           ];
           break;
         case 'dotenv':
-          message = `the API key from the ${this.dotenvLocation} file`;
+          message = `the API key from the ${this.apiKeyDotenvLocation} file`;
           suggestions = [
-            `Edit the ${this.dotenvLocation} file and set the XATA_API_KEY environment variable correctly`,
+            `Edit the ${this.apiKeyDotenvLocation} file and set the XATA_API_KEY environment variable correctly`,
             'You can generate or regenerate API keys at https://app.xata.io/settings'
           ];
           break;

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -33,6 +33,8 @@ export type APIKeyLocation = 'shell' | 'dotenv' | 'profile' | 'new';
 const moduleName = 'xata';
 const commonFlagsHelpGroup = 'Common';
 
+export const ENV_FILES = ['.env.local', '.env'];
+
 export abstract class BaseCommand extends Command {
   // Date formatting is not consistent across locales and timezones, so we need to set the locale and timezone for unit tests.
   // By default this will use the system locale and timezone.
@@ -110,8 +112,9 @@ export abstract class BaseCommand extends Command {
 
   async init() {
     if (process.env.XATA_API_KEY) this.apiKeyLocation = 'shell';
-    this.loadEnvFile('.env.local');
-    this.loadEnvFile('.env');
+    for (const envFile of ENV_FILES) {
+      this.loadEnvFile(envFile);
+    }
 
     const moduleName = 'xata';
     const search = cosmiconfigSync(moduleName, { searchPlaces: this.searchPlaces }).search();

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -15,6 +15,7 @@ import { z, ZodError } from 'zod';
 import { createAPIKeyThroughWebUI } from './auth-server.js';
 import { credentialsPath, getProfileName, Profile, readCredentials } from './credentials.js';
 import { reportBugURL } from './utils.js';
+import dotenvExpand from 'dotenv-expand';
 
 export const projectConfigSchema = z.object({
   databaseURL: z.string(),
@@ -103,8 +104,9 @@ export abstract class BaseCommand extends Command {
   }
 
   loadEnvFile(path: string) {
-    const env = dotenv.config({ path });
-    if (env.parsed?.['XATA_API_KEY']) {
+    let env = dotenv.config({ path });
+    env = dotenvExpand.expand(env);
+    if (!this.apiKeyDotenvLocation && env.parsed?.['XATA_API_KEY']) {
       this.apiKeyLocation = 'dotenv';
       this.apiKeyDotenvLocation = path;
     }

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -5,7 +5,7 @@ import { access, readFile, writeFile } from 'fs/promises';
 import path, { extname } from 'path';
 import which from 'which';
 import { createAPIKeyThroughWebUI } from '../../auth-server.js';
-import { BaseCommand } from '../../base.js';
+import { BaseCommand, ENV_FILES } from '../../base.js';
 import { isIgnored } from '../../git.js';
 import { xataDatabaseSchema } from '../../schema.js';
 import Browse from '../browse/index.js';
@@ -217,8 +217,8 @@ export default class Init extends BaseCommand {
   }
 
   async writeEnvFile(workspace: string, database: string) {
-    let envFile = '.env';
-    for (const file of ['.env.local', '.env']) {
+    let envFile = ENV_FILES[ENV_FILES.length - 1];
+    for (const file of ENV_FILES) {
       if (await this.access(file)) {
         envFile = file;
         break;

--- a/cli/src/commands/status/index.ts
+++ b/cli/src/commands/status/index.ts
@@ -49,7 +49,7 @@ export default class Status extends BaseCommand {
       case 'shell':
         return 'XATA_API_KEY environment variable in the current shell';
       case 'dotenv':
-        return `XATA_API_KEY environment variable at ${this.dotenvLocation}`;
+        return `XATA_API_KEY environment variable at ${this.apiKeyDotenvLocation}`;
       case 'profile':
         return `Credentials file at ${credentialsPath} witht the ${getProfileName()} profile`;
       case 'new':


### PR DESCRIPTION
- Use `.env.local` if it exists for storing env vars during `xata init`.
- Load `.env.local` and `.env` always in the CLI.