### PR TITLE
Broaden type for AbortSignal

### DIFF
--- a/.changeset/abort-signal.md
+++ b/.changeset/abort-signal.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/client": patch
+---
+
+Broaden type for AbortSignal

--- a/packages/client/src/api/fetcher.ts
+++ b/packages/client/src/api/fetcher.ts
@@ -28,7 +28,7 @@ const resolveUrl = (
 // Typed only the subset of the spec we actually use (to be able to build a simple mock)
 export type FetchImpl = (
   url: string,
-  init?: { body?: string; headers?: Record<string, string>; method?: string; signal?: AbortSignal }
+  init?: { body?: string; headers?: Record<string, string>; method?: string; signal?: any }
 ) => Promise<{
   ok: boolean;
   status: number;


### PR DESCRIPTION
Not standard type, fails on some platforms