### PR TITLE
eliminate insert method references

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -112,18 +112,18 @@ const user = await xata.db.users.create({
 });
 ```
 
-If you want to create a record with a specific ID, you can invoke `insert()`.
+If you want to create a record with a specific ID, you can provide the id as parameter to the `create()` method.
 
 ```ts
-const user = await xata.db.users.insert('user_admin', {
+const user = await xata.db.users.create('user_admin', {
   fullName: 'John Smith'
 });
 ```
 
-And if you want to create or insert a record with a specific ID, you can invoke `updateOrInsert()`.
+And if you want to create or update a record with a specific ID, you can invoke `createOrUpdate()` with an id parameter.
 
 ```ts
-const user = await xata.db.users.updateOrInsert('user_admin', {
+const user = await xata.db.users.createOrUpdate('user_admin', {
   fullName: 'John Smith'
 });
 ```


### PR DESCRIPTION
Docs fix for getting started guide.

Replaces references to the obsolete `insert` method with `create` and `createOrUpdate` in the [getting started guide](https://xata.io/docs/sdk/getting-started).

Partially addresses https://github.com/xataio/client-ts/issues/696
More work is likely needed on this document, but it's a quick first step to avoid some issues during initial user onboarding.