### PR TITLE
Add check for browser client execution

### DIFF
--- a/.changeset/shaggy-bikes-grin.md
+++ b/.changeset/shaggy-bikes-grin.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add more summarize functions

--- a/.changeset/wicked-wombats-exist.md
+++ b/.changeset/wicked-wombats-exist.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add a check for browser execution

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -8,6 +8,7 @@ import { SearchPlugin, SearchPluginResult } from './search';
 import { getAPIKey } from './util/apiKey';
 import { BranchStrategy, BranchStrategyOption, BranchStrategyValue, isBranchStrategyBuilder } from './util/branches';
 import { getCurrentBranchName, getDatabaseURL } from './util/config';
+import { getEnableBrowserVariable } from './util/environment';
 import { getFetchImplementation } from './util/fetch';
 import { AllRequired, StringKeys } from './util/types';
 import { generateUUID } from './util/uuid';
@@ -77,11 +78,10 @@ export const buildClient = <Plugins extends Record<string, XataPlugin> = {}>(plu
     }
 
     #parseOptions(options?: BaseClientOptions): SafeOptions {
-      const enableBrowser = options?.enableBrowser ?? false;
-
       // If is running from the browser and the user didn't pass `enableBrowser` we throw an error
+      const enableBrowser = options?.enableBrowser ?? getEnableBrowserVariable() ?? false;
       // @ts-ignore Window is not defined in Node
-      const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+      const isBrowser = typeof window !== 'undefined';
       if (isBrowser && !enableBrowser) {
         throw new Error(
           'You are trying to use Xata from the browser, which is potentially a non-secure environment. If you understand the security concerns, such as leaking your credentials, pass `enableBrowser: true` to the client options to remove this error.'

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -84,7 +84,7 @@ export const buildClient = <Plugins extends Record<string, XataPlugin> = {}>(plu
       const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
       if (isBrowser && !enableBrowser) {
         throw new Error(
-          'You are trying to use Xata from the browser, which is potentially a non-secure environment. If you understand the security concerns, pass `enableBrowser: true` to the client options to remove this error.'
+          'You are trying to use Xata from the browser, which is potentially a non-secure environment. If you understand the security concerns, such as leaking your credentials, pass `enableBrowser: true` to the client options to remove this error.'
         );
       }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -80,7 +80,9 @@ export const buildClient = <Plugins extends Record<string, XataPlugin> = {}>(plu
       const enableBrowser = options?.enableBrowser ?? false;
 
       // If is running from the browser and the user didn't pass `enableBrowser` we throw an error
-      if (typeof window !== 'undefined' && !enableBrowser) {
+      // @ts-ignore Window is not defined in Node
+      const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+      if (isBrowser && !enableBrowser) {
         throw new Error(
           'You are trying to use Xata from the browser, which is potentially a non-secure environment. If you understand the security concerns, pass `enableBrowser: true` to the client options to remove this error.'
         );

--- a/packages/client/src/types/global-variables.d.ts
+++ b/packages/client/src/types/global-variables.d.ts
@@ -2,6 +2,7 @@ declare const XATA_DATABASE_URL: string | undefined;
 declare const XATA_API_KEY: string | undefined;
 declare const XATA_BRANCH: string | undefined;
 declare const XATA_FALLBACK_BRANCH: string | undefined;
+declare const XATA_ENABLE_BROWSER: string | boolean | undefined;
 
 // Provider specific variable names
 declare const VERCEL_GIT_COMMIT_REF: string | undefined; // Vercel

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -55,6 +55,30 @@ export function getEnvironment(): Environment {
   };
 }
 
+export function getEnableBrowserVariable() {
+  try {
+    if (isObject(process) && isObject(process.env)) {
+      return process.env.XATA_ENABLE_BROWSER === 'true';
+    }
+  } catch (err) {
+    // Ignore: Should never happen
+  }
+
+  try {
+    if (isObject(Deno) && isObject(Deno.env)) {
+      return Deno.env.get('XATA_ENABLE_BROWSER') === 'true';
+    }
+  } catch (err) {
+    // Ignore: Will fail if not using --allow-env
+  }
+
+  try {
+    return XATA_ENABLE_BROWSER === true || XATA_ENABLE_BROWSER === 'true';
+  } catch (err) {
+    return undefined;
+  }
+}
+
 function getGlobalApiKey(): string | undefined {
   try {
     return XATA_API_KEY;

--- a/packages/client/src/util/environment.ts
+++ b/packages/client/src/util/environment.ts
@@ -57,7 +57,7 @@ export function getEnvironment(): Environment {
 
 export function getEnableBrowserVariable() {
   try {
-    if (isObject(process) && isObject(process.env)) {
+    if (isObject(process) && isObject(process.env) && process.env.XATA_ENABLE_BROWSER !== undefined) {
       return process.env.XATA_ENABLE_BROWSER === 'true';
     }
   } catch (err) {
@@ -65,7 +65,7 @@ export function getEnableBrowserVariable() {
   }
 
   try {
-    if (isObject(Deno) && isObject(Deno.env)) {
+    if (isObject(Deno) && isObject(Deno.env) && Deno.env.get('XATA_ENABLE_BROWSER') !== undefined) {
       return Deno.env.get('XATA_ENABLE_BROWSER') === 'true';
     }
   } catch (err) {


### PR DESCRIPTION
Error message:

> You are trying to use Xata from the browser, which is potentially a non-secure environment. If you understand the security concerns, pass `enableBrowser: true` to the client options to remove this error.