### PR TITLE
Pass fetch options from a query

### DIFF
--- a/.changeset/fuzzy-ties-argue.md
+++ b/.changeset/fuzzy-ties-argue.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Allow passing fetch options in some queries

--- a/.changeset/fuzzy-ties-argue.md
+++ b/.changeset/fuzzy-ties-argue.md
@@ -2,4 +2,4 @@
 '@xata.io/client': patch
 ---
 
-Allow passing fetch options in some queries
+[Experimental] Allow passing fetch options in some queries

--- a/packages/client/src/api/fetcher.ts
+++ b/packages/client/src/api/fetcher.ts
@@ -52,6 +52,7 @@ export type FetcherExtraProps = {
   signal?: AbortSignal;
   clientID?: string;
   sessionID?: string;
+  fetchOptions?: Record<string, unknown>;
 };
 
 export type ErrorWrapper<TError> = TError | { status: 'unknown'; payload: string };
@@ -124,7 +125,8 @@ export async function fetch<
   trace,
   signal,
   clientID,
-  sessionID
+  sessionID,
+  fetchOptions = {}
 }: FetcherOptions<TBody, THeaders, TQueryParams, TPathParams> & FetcherExtraProps): Promise<TData> {
   return trace(
     `${method.toUpperCase()} ${path}`,
@@ -141,6 +143,7 @@ export async function fetch<
       });
 
       const response = await fetchImpl(url, {
+        ...fetchOptions,
         method: method.toUpperCase(),
         body: body ? JSON.stringify(body) : undefined,
         headers: {

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -82,6 +82,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     this.#data.columns = data.columns ?? parent?.columns;
     this.#data.pagination = data.pagination ?? parent?.pagination;
     this.#data.cache = data.cache ?? parent?.cache;
+    this.#data.fetchOptions = data.fetchOptions ?? parent?.fetchOptions;
 
     this.any = this.any.bind(this);
     this.all = this.all.bind(this);

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -23,6 +23,7 @@ import { SummarizeExpression, SummarizeParams, SummarizeResult } from './summari
 type BaseOptions<T extends XataRecord> = {
   columns?: SelectableColumn<T>[];
   cache?: number;
+  fetchOptions?: Record<string, unknown>;
 };
 
 type CursorQueryOptions = {

--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -1625,6 +1625,7 @@ export class RestRepository<Record extends XataRecord>
           page: data.pagination,
           columns: data.columns ?? ['*']
         },
+        fetchOptions: data.fetchOptions,
         ...fetchProps
       });
 


### PR DESCRIPTION
```ts
const xata = getXataClient();

export default function Blog() {
  const posts = use(xata.db.posts.getAll({ fetchOptions: { cache: 'no-cache' } }));

  return (
    <div>
      <h1>Blog posts</h1>

      {data.map((post) => (<h2>{post.title}</h2>))}
    </div>
  );
}
```