### PR TITLE
Wait until a newly created API key is ready to be used

### DIFF
--- a/.changeset/afraid-chairs-sip.md
+++ b/.changeset/afraid-chairs-sip.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+Wait until a newly created API key is ready to be used

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -285,7 +285,9 @@ export default class Init extends BaseCommand {
         return;
       } catch (err) {
         if (err instanceof Error && err.message.includes('Invalid API key')) {
-          this.info('Waiting until the new API key is ready to be used...');
+          if (retries % 2 === 0) {
+            this.info('Waiting until the new API key is ready to be used...');
+          }
           await new Promise((resolve) => setTimeout(resolve, 1000));
         } else {
           throw err;

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -233,8 +233,11 @@ export default class Init extends BaseCommand {
 
     if (!apiKey) {
       apiKey = await createAPIKeyThroughWebUI();
+      this.apiKeyLocation = 'new';
       // Any following API call must use this API key
       process.env.XATA_API_KEY = apiKey;
+
+      await this.waitUntilAPIKeyIsValid(workspace, region, database);
     }
     this.info(
       'The fallback branch will be used when you are in a git branch that does not have a corresponding Xata branch (a branch with the same name, or linked explicitly)'
@@ -269,6 +272,27 @@ export default class Init extends BaseCommand {
     await writeFile(envFile, content);
 
     await this.ignoreEnvFile(envFile);
+  }
+
+  // New API keys need to be replicated until can be used in a particular region/database
+  async waitUntilAPIKeyIsValid(workspace: string, region: string, database: string) {
+    const xata = await this.getXataClient();
+    const maxRetries = 10;
+    let retries = 0;
+    while (retries++ < maxRetries) {
+      try {
+        await xata.branches.getBranchList({ workspace, region, database });
+        return;
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('Invalid API key')) {
+          this.info('Waiting until the new API key is ready to be used...');
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        } else {
+          throw err;
+        }
+      }
+    }
+    this.error(`The new API key could not be used after ${maxRetries} seconds. Please try again.`);
   }
 
   async ignoreEnvFile(envFile: string) {


### PR DESCRIPTION
Closes https://github.com/xataio/client-ts/issues/754

We do API requests to the data plane right after creating an API key, and that can be too fast and the API key might not be replicated yet.

With this PR we check up to 10 times and 10 seconds to see if the API is valid after that.