### PR TITLE
Do not error if cache fails

### DIFF
--- a/.changeset/olive-pans-study.md
+++ b/.changeset/olive-pans-study.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/plugin-client-cloudflare': patch
+---
+
+Do not throw error if limit reached


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2181866/203029921-4ca9b9c4-db4c-49ff-a8e4-15c13c77c647.png)

On my test account, which is not on Enterprise plan. We shouldn't reach this issue easily, but in case we do don't error on user's code. We will need to add monitoring if this happens before GA, good enough for now.