### PR TITLE
Improve workers compilation step

### DIFF
--- a/.changeset/soft-chicken-relate.md
+++ b/.changeset/soft-chicken-relate.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fix race condition with workers build step

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xata.io/cli",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xata.io/cli",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.20.2",
@@ -23,7 +23,7 @@
         "@rollup/plugin-virtual": "^3.0.1",
         "@types/ini": "^1.3.31",
         "@types/prompts": "^2.4.1",
-        "@xata.io/client": "^0.21.2",
+        "@xata.io/client": "^0.21.3",
         "@xata.io/codegen": "^0.21.0",
         "@xata.io/importer": "^0.3.2",
         "ansi-regex": "^6.0.1",
@@ -48,6 +48,7 @@
         "relaxed-json": "^1.0.3",
         "rollup-plugin-esbuild": "^5.0.0",
         "rollup-plugin-hypothetical": "^2.1.1",
+        "rollup-plugin-import-cdn": "^0.2.2",
         "rollup-plugin-virtual-fs": "^4.0.1-alpha.0",
         "text-table": "^0.2.0",
         "tmp": "^0.2.1",
@@ -2312,9 +2313,9 @@
       }
     },
     "node_modules/@xata.io/client": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.21.2.tgz",
-      "integrity": "sha512-+ZoAgGGy6+In6HDjqSRCzxKcsodFZDd6stGgvtpATt+bUyL8glkk61EYh3iKKrlWBtfG5lZPK9LEQcVEdf6icg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.21.3.tgz",
+      "integrity": "sha512-y0ITyIqw8JcqlynxvoAIJLiPj5j6CldIcwlOuUIXJ9RyxipevCCliDT/PbJUegHkj3hS+eTPPT9SVmvRJBQ6SA==",
       "peerDependencies": {
         "typescript": ">=4.5"
       }
@@ -13641,6 +13642,22 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/rollup-plugin-import-cdn": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-cdn/-/rollup-plugin-import-cdn-0.2.2.tgz",
+      "integrity": "sha512-hfHB3ZGUSGcWVx1/GAdrk+wOkPIMaI1Mr41X6Knpi1r9OTvOPw1iIyb7VLdjvKeT/vfM5RkyVSw8890p4QMC2w==",
+      "dependencies": {
+        "es-module-lexer": "^0.10.5"
+      },
+      "peerDependencies": {
+        "rollup": "^2.70.2"
+      }
+    },
+    "node_modules/rollup-plugin-import-cdn/node_modules/es-module-lexer": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.5.tgz",
+      "integrity": "sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw=="
+    },
     "node_modules/rollup-plugin-virtual-fs": {
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-virtual-fs/-/rollup-plugin-virtual-fs-4.0.1-alpha.0.tgz",
@@ -16947,9 +16964,9 @@
       }
     },
     "@xata.io/client": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.21.2.tgz",
-      "integrity": "sha512-+ZoAgGGy6+In6HDjqSRCzxKcsodFZDd6stGgvtpATt+bUyL8glkk61EYh3iKKrlWBtfG5lZPK9LEQcVEdf6icg==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@xata.io/client/-/client-0.21.3.tgz",
+      "integrity": "sha512-y0ITyIqw8JcqlynxvoAIJLiPj5j6CldIcwlOuUIXJ9RyxipevCCliDT/PbJUegHkj3hS+eTPPT9SVmvRJBQ6SA==",
       "requires": {}
     },
     "@xata.io/codegen": {
@@ -26109,6 +26126,21 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.1.tgz",
       "integrity": "sha512-Ne40a4qyXap1C41ObstbgfklT8VGEirJ57ZRIEgkEMaEIxdx5kNwdzrxfyS9cn59tAYROHh+2hfiFU4sTQt1rw=="
+    },
+    "rollup-plugin-import-cdn": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-import-cdn/-/rollup-plugin-import-cdn-0.2.2.tgz",
+      "integrity": "sha512-hfHB3ZGUSGcWVx1/GAdrk+wOkPIMaI1Mr41X6Knpi1r9OTvOPw1iIyb7VLdjvKeT/vfM5RkyVSw8890p4QMC2w==",
+      "requires": {
+        "es-module-lexer": "^0.10.5"
+      },
+      "dependencies": {
+        "es-module-lexer": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.10.5.tgz",
+          "integrity": "sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw=="
+        }
+      }
     },
     "rollup-plugin-virtual-fs": {
       "version": "4.0.1-alpha.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -58,6 +58,7 @@
     "relaxed-json": "^1.0.3",
     "rollup-plugin-esbuild": "^5.0.0",
     "rollup-plugin-hypothetical": "^2.1.1",
+    "rollup-plugin-import-cdn": "^0.2.2",
     "rollup-plugin-virtual-fs": "^4.0.1-alpha.0",
     "text-table": "^0.2.0",
     "tmp": "^0.2.1",

--- a/cli/src/commands/workers/watch.ts
+++ b/cli/src/commands/workers/watch.ts
@@ -25,7 +25,9 @@ export default class WorkersCompile extends BaseCommand {
     const { apiKey } = (await this.getProfile()) ?? {};
 
     buildWatcher({
-      compile: (path) => compileWorkers(path),
+      compile: async (path) => {
+        return await compileWorkers(path);
+      },
       run: async (results) => {
         const mounts = results.flat().map(({ name, modules, main }) => [
           name,

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -133,13 +133,13 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
     return [];
   }
 
-  console.log(`[watcher] found ${Object.keys(functions).length} workers in ${file}`);
-
   const versions = await getDependencyVersions();
 
   const compiledWorkers: WorkerScript[] = [];
 
-  for (const [name, worker] of Object.entries(functions)) {
+  for await (const [name, worker] of Object.entries(functions)) {
+    console.log(`[watcher] compiling worker ${name} in ${file}`);
+
     try {
       const code = workerCode(worker, external);
       const { outputText: entry } = ts.transpileModule(code, {
@@ -162,6 +162,8 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
         main: output[0].fileName,
         modules: output.map((o) => ({ name: o.fileName, content: (o as OutputChunk).code }))
       });
+
+      console.log(`[watcher] compiled worker ${name} in ${file}`);
     } catch (error) {
       console.error(`[watcher] error compiling worker ${name} in file ${file}`);
       console.error(error);

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -55,7 +55,7 @@ export function buildWatcher<T extends WorkerScript>({
   watcher
     .on('add', async (path) => {
       console.log(`[watcher] add ${path}`);
-      modules[path] = await compile(path);
+      modules[path] = [];
     })
     .on('change', async (path) => {
       console.log(`[watcher] change ${path}`);
@@ -67,6 +67,12 @@ export function buildWatcher<T extends WorkerScript>({
     })
     .on('ready', async () => {
       console.log('[watcher] ready');
+
+      const paths = Object.keys(modules);
+      for (const path of paths) {
+        modules[path] = await compile(path);
+      }
+
       if (run) {
         stopServer = await run(Object.values(modules).flat());
       }

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -52,10 +52,15 @@ export function buildWatcher<T extends WorkerScript>({
 
   watcher
     .on('add', async (path) => {
+      console.log(`[watcher] add ${path}`);
       modules[path] = await compile(path);
     })
-    .on('change', updateModule)
-    .on('error', () => {
+    .on('change', async (path) => {
+      console.log(`[watcher] change ${path}`);
+      await updateModule(path);
+    })
+    .on('error', (error) => {
+      console.error(`[watcher] error ${error}`);
       throw new Error('Watcher error');
     })
     .on('ready', async () => {
@@ -69,6 +74,8 @@ export function buildWatcher<T extends WorkerScript>({
 }
 
 export async function compileWorkers(file: string): Promise<WorkerScript[]> {
+  console.log(`[compile] ${file}`);
+
   const external: string[] = [];
   const functions: Record<string, string> = {};
 

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -5,6 +5,7 @@ import presetTypeScript from '@babel/preset-typescript';
 import presetReact from '@babel/preset-react';
 import type { CallExpression, FunctionDeclaration } from '@babel/types';
 import commonjs from '@rollup/plugin-commonjs';
+import resolve from '@rollup/plugin-node-resolve';
 import virtual from '@rollup/plugin-virtual';
 import chokidar from 'chokidar';
 import { readFile } from 'fs/promises';
@@ -155,7 +156,7 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
       const bundle = await rollup({
         input: 'entry',
         output: { file: `file://bundle.js`, format: 'es' },
-        plugins: [importCdn({ fetchImpl: fetch, versions }), virtual({ entry }), commonjs()]
+        plugins: [virtual({ entry }), importCdn({ fetchImpl: fetch, versions }), resolve(), commonjs()]
       });
 
       const { output } = await bundle.generate({});

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -65,7 +65,7 @@ export function buildWatcher<T extends WorkerScript>({
       throw new Error('Watcher error');
     })
     .on('ready', async () => {
-      console.log('Watcher ready');
+      console.log('[watcher] ready');
       if (run) {
         stopServer = await run(Object.values(modules).flat());
       }
@@ -75,17 +75,14 @@ export function buildWatcher<T extends WorkerScript>({
 }
 
 export async function compileWorkers(file: string): Promise<WorkerScript[]> {
-  console.log(`[compile] ${file}`);
-
   const external: string[] = [];
   const functions: Record<string, string> = {};
-
-  console.log('[compile] presets: ', [presetTypeScript, presetReact]);
 
   try {
     const fileContents = await readFile(file, 'utf-8');
 
     babel.transformSync(fileContents, {
+      filename: file,
       presets: [presetTypeScript, presetReact],
       plugins: [
         (): PluginItem => {

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -138,8 +138,6 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
   const compiledWorkers: WorkerScript[] = [];
 
   for await (const [name, worker] of Object.entries(functions)) {
-    console.log(`[watcher] compiling worker ${name} in ${file}`);
-
     try {
       const code = workerCode(worker, external);
       const { outputText: entry } = ts.transpileModule(code, {

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -68,8 +68,7 @@ export function buildWatcher<T extends WorkerScript>({
     .on('ready', async () => {
       console.log('[watcher] ready');
 
-      const paths = Object.keys(modules);
-      for (const path of paths) {
+      for await (const path of Object.keys(modules)) {
         modules[path] = await compile(path);
       }
 

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -11,6 +11,7 @@ import chokidar from 'chokidar';
 import { OutputChunk, rollup } from 'rollup';
 import ts from 'typescript';
 import { z } from 'zod';
+import { readFile } from 'fs/promises';
 
 type BuildWatcherOptions<T> = {
   compile: (path: string) => Promise<T[]>;
@@ -79,8 +80,12 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
   const external: string[] = [];
   const functions: Record<string, string> = {};
 
+  console.log('[compile] presets: ', [presetTypeScript, presetReact]);
+
   try {
-    babel.transformFileSync(file, {
+    const fileContents = await readFile(file, 'utf-8');
+
+    babel.transformSync(fileContents, {
       presets: [presetTypeScript, presetReact],
       plugins: [
         (): PluginItem => {

--- a/cli/src/workers.ts
+++ b/cli/src/workers.ts
@@ -135,6 +135,8 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
     return [];
   }
 
+  console.log(`[watcher] found ${Object.keys(functions).length} workers in ${file}`);
+
   const compiledWorkers: WorkerScript[] = [];
 
   for (const [name, worker] of Object.entries(functions)) {
@@ -161,6 +163,7 @@ export async function compileWorkers(file: string): Promise<WorkerScript[]> {
         modules: output.map((o) => ({ name: o.fileName, content: (o as OutputChunk).code }))
       });
     } catch (error) {
+      console.error(`[watcher] error compiling worker ${name} in file ${file}`);
       console.error(error);
     }
   }


### PR DESCRIPTION
- Move compile, after watcher is ready
- Add CDN import in case resolve fails (npm install not run recently)
  - This is debatable if it should fail, I'll think about it but for now let's play safe
- Add more logs