### PR TITLE
Improvements for date time fields

### DIFF
--- a/.changeset/nervous-maps-help.md
+++ b/.changeset/nervous-maps-help.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Improve types for datetime fields accepting strings

--- a/.changeset/orange-moles-nail.md
+++ b/.changeset/orange-moles-nail.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fix now default value in schema edit

--- a/.github/workflows/tsc.yml
+++ b/.github/workflows/tsc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ['next', 'beta', 'latest', '~4.7']
+        target: ['next', 'beta', 'latest', '~4.8', '~4.7']
 
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/cli/src/commands/schema/edit.ts
+++ b/cli/src/commands/schema/edit.ts
@@ -737,6 +737,9 @@ function parseDefaultValue(type: string, val: string): string | undefined {
   } else if (type === 'link') {
     return val ? String(val) : undefined;
   } else if (type === 'datetime') {
+    // Date fields have special values
+    if (['now'].includes(val)) return val;
+
     const date = new Date(val);
     return isNaN(date.getTime()) ? undefined : date.toISOString();
   } else {

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -30,8 +30,7 @@ type BaseOptions<T extends XataRecord> = {
 type CursorQueryOptions = {
   pagination?: CursorNavigationOptions & OffsetNavigationOptions;
   filter?: never;
-  // Fix for TS 4.7 not inferring `never` for `sort`
-  sort?: never | unknown;
+  sort?: never;
 };
 
 type OffsetQueryOptions<T extends XataRecord> = {
@@ -174,10 +173,10 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
    * })
    * ```
    *
-   * @param filters A filter object
+   * @param filter A filter object
    * @returns A new Query object.
    */
-  filter(filters?: Filter<Record>): Query<Record, Result>;
+  filter(filter?: Filter<Record>): Query<Record, Result>;
 
   filter(a: any, b?: any): Query<Record, Result> {
     if (arguments.length === 1) {

--- a/packages/client/src/schema/query.ts
+++ b/packages/client/src/schema/query.ts
@@ -78,7 +78,7 @@ export class Query<Record extends XataRecord, Result extends XataRecord = Record
     this.#data.filter.$all = data.filter?.$all ?? parent?.filter?.$all;
     this.#data.filter.$not = data.filter?.$not ?? parent?.filter?.$not;
     this.#data.filter.$none = data.filter?.$none ?? parent?.filter?.$none;
-    this.#data.sort = data.sort ?? parent?.sort;
+    this.#data.sort = (data.sort ?? parent?.sort) as QueryOptions<Record>['sort']; // Fix for TS =4.7
     this.#data.columns = data.columns ?? parent?.columns;
     this.#data.consistency = data.consistency ?? parent?.consistency;
     this.#data.pagination = data.pagination ?? parent?.pagination;

--- a/packages/client/src/schema/record.ts
+++ b/packages/client/src/schema/record.ts
@@ -128,15 +128,21 @@ export function isXataRecord(x: any): x is XataRecord & Record<string, unknown> 
   return isIdentifiable(x) && isObject(metadata) && typeof metadata.version === 'number';
 }
 
+type EditableDataFields<T> = T extends XataRecord
+  ? { id: string } | string
+  : NonNullable<T> extends XataRecord
+  ? { id: string } | string | null | undefined
+  : T extends Date
+  ? string | Date
+  : NonNullable<T> extends Date
+  ? string | Date | null | undefined
+  : T;
+
 export type EditableData<O extends XataRecord> = Identifiable &
   Partial<
     Omit<
       {
-        [K in keyof O]: O[K] extends XataRecord
-          ? { id: string } | string
-          : NonNullable<O[K]> extends XataRecord
-          ? { id: string } | string | null | undefined
-          : O[K];
+        [K in keyof O]: EditableDataFields<O[K]>;
       },
       keyof XataRecord
     >

--- a/test/integration/dates.test.ts
+++ b/test/integration/dates.test.ts
@@ -36,6 +36,14 @@ describe('dates', () => {
     expect(record.birthDate?.toISOString()).toEqual(birthDate.toISOString());
   });
 
+  test("add a record with a string date (it's parsed)", async () => {
+    const birthDate = new Date();
+    const record = await xata.db.users.create({ full_name: 'foo2', birthDate: birthDate.toISOString() });
+
+    expect(record.birthDate instanceof Date).toEqual(true);
+    expect(record.birthDate?.toISOString()).toEqual(birthDate.toISOString());
+  });
+
   test('add a record without a date (optional)', async () => {
     const record = await xata.db.users.create({ full_name: 'optional' });
 


### PR DESCRIPTION
- Add tsc check for 4.8
- Fix types in TS 4.7 for sort
- Fix `now` modifier for default value in CLI
- Allow strings in datefield types

Closes #776 
Closes #812