### PR TITLE
Fix build PR workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: Publish build
         if: ${{ steps.secrets.outputs.exist == 'true' && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
         run: |
           cat << EOF > .changeset/force-canary-build.md
           ---


### PR DESCRIPTION
We're missing one env variable in the workflow execution