### PR TITLE
default value for editing undefined string column

### DIFF
--- a/.changeset/five-stingrays-rescue.md
+++ b/.changeset/five-stingrays-rescue.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+default value for strings is not longer set to "undefined" if left empty

--- a/cli/src/commands/schema/edit.ts
+++ b/cli/src/commands/schema/edit.ts
@@ -734,7 +734,10 @@ function validateOptionalBoolean(value?: string) {
   return true;
 }
 
-function parseDefaultValue(type: string, val: string): string | undefined {
+function parseDefaultValue(type: string, val?: string): string | undefined {
+  if (val === undefined) {
+    return undefined;
+  }
   const num = String(val).length > 0 ? +val : undefined;
 
   if (type === 'string') {
@@ -746,9 +749,9 @@ function parseDefaultValue(type: string, val: string): string | undefined {
   } else if (type === 'bool') {
     return String(parseBoolean(val));
   } else if (type === 'email') {
-    return val || undefined;
+    return val;
   } else if (type === 'link') {
-    return val ? String(val) : undefined;
+    return String(val);
   } else if (type === 'datetime') {
     // Date fields have special values
     if (['now'].includes(val)) return val;


### PR DESCRIPTION
Fixes: https://github.com/xataio/client-ts/issues/863

Tested locally for:

Strings with default set / not set
Emails with default set / not set
Links with default not set.