### PR TITLE
Move random data to importers

### DIFF
--- a/.changeset/wild-baboons-matter.md
+++ b/.changeset/wild-baboons-matter.md
@@ -1,0 +1,6 @@
+---
+'@xata.io/importer': patch
+'@xata.io/cli': patch
+---
+
+Expose random data command programmatically

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -82,11 +82,16 @@ jobs:
       - name: Compile
         run: pnpm build
 
+      - name: Configure npm registry token
+        if: ${{ steps.secrets.outputs.exist == 'true' }}
+        run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish build
         if: ${{ steps.secrets.outputs.exist == 'true' && github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cat << EOF > .changeset/force-canary-build.md
           ---

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -82,16 +82,11 @@ jobs:
       - name: Compile
         run: pnpm build
 
-      - name: Configure npm registry token
-        if: ${{ steps.secrets.outputs.exist == 'true' }}
-        run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish build
         if: ${{ steps.secrets.outputs.exist == 'true' && github.event_name == 'pull_request' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cat << EOF > .changeset/force-canary-build.md
           ---

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,6 @@
     "@babel/core": "^7.20.12",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
-    "@faker-js/faker": "^7.6.0",
     "@oclif/core": "^1.25.0",
     "@oclif/plugin-help": "^5",
     "@oclif/plugin-not-found": "^2.3.16",

--- a/cli/src/commands/random-data/index.ts
+++ b/cli/src/commands/random-data/index.ts
@@ -1,6 +1,5 @@
-import { faker } from '@faker-js/faker';
 import { Flags } from '@oclif/core';
-import { Column } from '@xata.io/codegen';
+import { generateRandomData } from '@xata.io/importer';
 import chalk from 'chalk';
 import { BaseCommand } from '../../base.js';
 import { pluralize } from '../../utils.js';
@@ -49,11 +48,16 @@ export default class RandomData extends BaseCommand {
     const tables = tablesFlag.length > 0 ? schemaTables.filter((t) => tablesFlag.includes(t.name)) : schemaTables;
 
     for (const table of tables) {
-      const records: Record<string, unknown>[] = [];
-      for (let index = 0; index < totalRecords; index++) {
-        records.push(this.randomRecord(table.columns));
-      }
-      await xata.records.bulkInsertTableRecords({ workspace, region, database, branch, table: table.name, records });
+      const records = generateRandomData(table, totalRecords);
+
+      await xata.records.bulkInsertTableRecords({
+        workspace,
+        region,
+        database,
+        branch,
+        table: table.name,
+        records
+      });
 
       this.info(
         `Inserted ${chalk.bold(totalRecords)} random ${pluralize('record', totalRecords)} in the ${chalk.bold(
@@ -68,65 +72,4 @@ export default class RandomData extends BaseCommand {
       )} ${pluralize('table', tables.length)}`
     );
   }
-
-  randomRecord(columns: Column[]) {
-    const record: Record<string, unknown> = {};
-    for (const column of columns) {
-      record[column.name] = this.randomData(column);
-    }
-    return record;
-  }
-
-  randomData(column: Column) {
-    switch (column.type) {
-      case 'text':
-        return faker.lorem.paragraphs(rand(2, 3));
-      case 'email':
-        return faker.internet.email(undefined, undefined, 'acme.pets');
-      case 'int':
-        return rand(1, 100);
-      case 'float':
-        return rand(1, 10000) / rand(1, 100);
-      case 'bool':
-        return rand(0, 1) === 1;
-      case 'object':
-        return this.randomRecord(column.columns || []);
-      case 'multiple':
-        return faker.random.words(rand(1, 3)).split(' ');
-      case 'string':
-        return randomString(column.name);
-      case 'datetime':
-        return faker.date.recent(rand(1, 10));
-      default:
-        return undefined;
-    }
-  }
-}
-
-function rand(min: number, max: number) {
-  return Math.floor(Math.random() * (max - min) + min);
-}
-
-const generators: Record<string, () => string> = {
-  city: () => faker.address.city(),
-  country: () => faker.address.country(),
-  county: () => faker.address.county(),
-  state: () => faker.address.state(),
-  street: () => faker.address.street(),
-  timezone: () => faker.address.timeZone(),
-  tz: () => faker.address.timeZone(),
-  zipcode: () => faker.address.zipCode(),
-  zip: () => faker.address.zipCode(),
-  department: () => faker.commerce.department(),
-  product: () => faker.commerce.product(),
-  company: () => faker.company.companyName(),
-  firstName: () => faker.name.firstName(),
-  lastName: () => faker.name.lastName(),
-  phone: () => faker.phone.phoneNumber('501-###-###')
-};
-
-function randomString(columnName: string) {
-  const gen = generators[columnName.toLowerCase()];
-  if (gen) return gen();
-  return faker.random.words(2);
 }

--- a/packages/importer/package.json
+++ b/packages/importer/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/xataio/client-ts/blob/main/importer/README.md",
   "dependencies": {
+    "@faker-js/faker": "^7.6.0",
     "@xata.io/client": "workspace:*",
     "camelcase": "^7.0.1",
     "csvtojson": "^2.0.10",

--- a/packages/importer/src/index.ts
+++ b/packages/importer/src/index.ts
@@ -16,3 +16,4 @@ export type ParseOptions = {
 export { parseFile as parseCSVFile, parseStream as parseCSVStream, parseString as parseCSVString } from './csv';
 export { createProcessor } from './processor';
 export type { CompareSchemaResult, TableInfo } from './processor';
+export { generateRandomData } from './random-data';

--- a/packages/importer/src/random-data.ts
+++ b/packages/importer/src/random-data.ts
@@ -1,0 +1,73 @@
+import { faker } from '@faker-js/faker';
+import { Schemas } from '@xata.io/client';
+
+export function generateRandomData(table: Schemas.Table, size: number) {
+  const records: Record<string, unknown>[] = [];
+
+  for (let index = 0; index < size; index++) {
+    records.push(randomRecord(table.columns));
+  }
+
+  return records;
+}
+
+function randomRecord(columns: Schemas.Column[]) {
+  const record: Record<string, unknown> = {};
+  for (const column of columns) {
+    record[column.name] = randomData(column);
+  }
+  return record;
+}
+
+function randomData(column: Schemas.Column) {
+  switch (column.type) {
+    case 'text':
+      return faker.lorem.paragraphs(rand(2, 3));
+    case 'email':
+      return faker.internet.email(undefined, undefined, 'acme.pets');
+    case 'int':
+      return rand(1, 100);
+    case 'float':
+      return rand(1, 10000) / rand(1, 100);
+    case 'bool':
+      return rand(0, 1) === 1;
+    case 'object':
+      return randomRecord(column.columns || []);
+    case 'multiple':
+      return faker.random.words(rand(1, 3)).split(' ');
+    case 'string':
+      return randomString(column.name);
+    case 'datetime':
+      return faker.date.recent(rand(1, 10));
+    default:
+      return undefined;
+  }
+}
+
+function rand(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
+const generators: Record<string, () => string> = {
+  city: () => faker.address.city(),
+  country: () => faker.address.country(),
+  county: () => faker.address.county(),
+  state: () => faker.address.state(),
+  street: () => faker.address.street(),
+  timezone: () => faker.address.timeZone(),
+  tz: () => faker.address.timeZone(),
+  zipcode: () => faker.address.zipCode(),
+  zip: () => faker.address.zipCode(),
+  department: () => faker.commerce.department(),
+  product: () => faker.commerce.product(),
+  company: () => faker.company.companyName(),
+  firstName: () => faker.name.firstName(),
+  lastName: () => faker.name.lastName(),
+  phone: () => faker.phone.phoneNumber('501-###-###')
+};
+
+function randomString(columnName: string) {
+  const gen = generators[columnName.toLowerCase()];
+  if (gen) return gen();
+  return faker.random.words(2);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,7 +99,6 @@ importers:
       '@babel/preset-react': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
       '@babel/types': ^7.20.7
-      '@faker-js/faker': ^7.6.0
       '@oclif/core': ^1.25.0
       '@oclif/plugin-help': ^5
       '@oclif/plugin-not-found': ^2.3.16
@@ -161,7 +160,6 @@ importers:
       '@babel/core': 7.20.12
       '@babel/preset-react': 7.18.6_@babel+core@7.20.12
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
-      '@faker-js/faker': 7.6.0
       '@oclif/core': 1.25.0
       '@oclif/plugin-help': 5.1.20
       '@oclif/plugin-not-found': 2.3.16
@@ -246,12 +244,14 @@ importers:
 
   packages/importer:
     specifiers:
+      '@faker-js/faker': ^7.6.0
       '@types/csvtojson': ^2.0.0
       '@xata.io/client': workspace:*
       camelcase: ^7.0.1
       csvtojson: ^2.0.10
       transliteration: ^2.3.5
     dependencies:
+      '@faker-js/faker': 7.6.0
       '@xata.io/client': link:../client
       camelcase: 7.0.1
       csvtojson: 2.0.10


### PR DESCRIPTION
Expose random data logic for programmatic use. Expected uses:

- Frontend UI
- SDK plugin: `xata.import.random(size, <options>)`