### PR TITLE
Fix flakey test in vector search

### DIFF
--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -6,7 +6,7 @@ let xata: XataClient;
 let hooks: TestEnvironmentResult['hooks'];
 
 const users = [
-  { full_name: 'r1', vector: [0.1, 0.2, 0.3, 0.5] },
+  { full_name: 'r1', vector: [0.1, 0.2, 0.3, 0.6] },
   { full_name: 'r2', vector: [4, 3, 2, 1] },
   { full_name: 'r3', vector: [0.5, 0.2, 0.3, 0.1] },
   { full_name: 'r4', vector: [1, 2, 3, 4] }


### PR DESCRIPTION
This makes the vectors just a bit farther apart so we don't get flakeyness in the returned order.

Ran 10 times and I think the flakeyness is fixed.
