### PR TITLE
Introduce BranchOp

### DIFF
--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1305,7 +1305,7 @@ class MigrationRequestsApi {
     region: string;
     database: Schemas.DBName;
     migrationRequest: Schemas.MigrationRequestNumber;
-  }): Promise<Schemas.Commit> {
+  }): Promise<Schemas.BranchOp> {
     return operationsByTag.migrationRequests.mergeMigrationRequest({
       pathParams: { workspace, region, dbName: database, mrNumber: migrationRequest },
       ...this.extraProps

--- a/packages/client/src/api/dataPlaneComponents.ts
+++ b/packages/client/src/api/dataPlaneComponents.ts
@@ -1127,7 +1127,7 @@ export type MergeMigrationRequestVariables = {
 } & DataPlaneFetcherExtraProps;
 
 export const mergeMigrationRequest = (variables: MergeMigrationRequestVariables, signal?: AbortSignal) =>
-  dataPlaneFetch<Schemas.Commit, MergeMigrationRequestError, undefined, {}, {}, MergeMigrationRequestPathParams>({
+  dataPlaneFetch<Schemas.BranchOp, MergeMigrationRequestError, undefined, {}, {}, MergeMigrationRequestPathParams>({
     url: '/dbs/{dbName}/migrations/{mrNumber}/merge',
     method: 'post',
     ...variables,

--- a/packages/client/src/api/dataPlaneSchemas.ts
+++ b/packages/client/src/api/dataPlaneSchemas.ts
@@ -447,9 +447,7 @@ export type Commit = {
   id: string;
   parentID?: string;
   mergeParentID?: string;
-  status: MigrationStatus;
   createdAt: DateTime;
-  modifiedAt?: DateTime;
   operations: MigrationOp[];
 };
 
@@ -457,6 +455,17 @@ export type SchemaEditScript = {
   sourceMigrationID?: string;
   targetMigrationID?: string;
   operations: MigrationOp[];
+};
+
+export type BranchOp = {
+  id: string;
+  parentID?: string;
+  title?: string;
+  message?: string;
+  status: MigrationStatus;
+  createdAt: DateTime;
+  modifiedAt?: DateTime;
+  migration?: Commit;
 };
 
 /**


### PR DESCRIPTION
When merging a PR we will return a BranchOp instead of a Commit. The operation contains the Commit object. The Commit object itself has no more status of modifiedAt field and will become immutable in the backend.