### PR TITLE
Add vector to schema edit source

### DIFF
--- a/cli/src/schema.ts
+++ b/cli/src/schema.ts
@@ -33,7 +33,7 @@ export type Column = {
 export const columnSchema: z.ZodSchema<Column> = z.lazy(() =>
   z.object({
     name: z.string(),
-    type: z.enum(['bool', 'int', 'float', 'string', 'text', 'email', 'multiple', 'link', 'object', 'datetime']),
+    type: z.enum(['bool', 'int', 'float', 'string', 'text', 'email', 'multiple', 'link', 'object', 'datetime', 'vector']),
     unique: z.boolean().optional(),
     notNull: z.boolean().optional(),
     defaultValue: z.string().optional(),


### PR DESCRIPTION
We missed one occurrence of the `vector` type not being added