### PR TITLE
bugfix: CLI localhost:port/new redirects

### DIFF
--- a/.changeset/eighty-weeks-provide.md
+++ b/.changeset/eighty-weeks-provide.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+bugfix: CLI http://localhost:<port>/new redirects correctly

--- a/cli/src/auth-server.test.ts
+++ b/cli/src/auth-server.test.ts
@@ -56,6 +56,7 @@ describe('handler', () => {
     const [status, headers] = writeHead.mock.calls[0];
     expect(status).toEqual(302);
     expect(String(headers.location).startsWith('https://app.xata.io/new-api-key?pub=')).toBeTruthy();
+    expect(String(headers.location).includes('9999')).toBeTruthy();
     expect(res.end).toHaveBeenCalledWith();
     expect(callback).not.toHaveBeenCalled();
   });

--- a/cli/src/auth-server.test.ts
+++ b/cli/src/auth-server.test.ts
@@ -45,7 +45,7 @@ describe('handler', () => {
     const httpHandler = handler(publicKey, privateKey, passphrase, callback);
 
     const writeHead = vi.fn();
-    const req = { method: 'GET', url: '/new' } as unknown as IncomingMessage;
+    const req = { method: 'GET', url: '/new', socket: { localPort: 9999 } } as unknown as IncomingMessage;
     const res = {
       writeHead,
       end: vi.fn()
@@ -107,8 +107,8 @@ describe('handler', () => {
     httpHandler(req, res);
 
     expect(res.writeHead).toHaveBeenCalledWith(500);
-    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('Something went wrong:'))
-    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('decoding error'))
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('Something went wrong:'));
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('decoding error'));
     expect(callback).not.toHaveBeenCalled();
   });
 

--- a/cli/src/auth-server.ts
+++ b/cli/src/auth-server.ts
@@ -20,7 +20,7 @@ export function handler(publicKey: string, privateKey: string, passphrase: strin
 
       const parsedURL = url.parse(req.url ?? '', true);
       if (parsedURL.pathname === '/new') {
-        const port = +(parsedURL.port || 80);
+        const port = req.socket.localPort ?? 80;
         res.writeHead(302, {
           location: generateURL(port, publicKey)
         });


### PR DESCRIPTION
<img width="1353" alt="Screenshot 2023-05-24 at 14 48 18" src="https://github.com/xataio/client-ts/assets/6640874/7afb2425-d629-49d4-a9fb-4303557277dc">

Clicking this link sends you to a url like this:

https://app.xata.io/new-api-key?pub=key&name=Xata+CLI&redirect=http%3A%2F%2Flocalhost%3A80

But the redirect url was always http://localhost:80 which is wrong and fails the flow completely.

(I was trying to paste it into an incognito tab for reasons)

Test with: `npx @xata.io/cli@0.0.0-alpha.vc5b0c25 auth login` and click the link

