### PR TITLE
Make `xata` property enumerable

### DIFF
--- a/.changeset/beige-donkeys-own.md
+++ b/.changeset/beige-donkeys-own.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/client": patch
+---
+
+Make `xata` property enumerable

--- a/packages/client/src/schema/repository.ts
+++ b/packages/client/src/schema/repository.ts
@@ -2015,9 +2015,9 @@ export const initObject = <T>(
     return db[table].delete(record['id'] as string);
   };
 
-  record.xata = metadata;
+  record.xata = Object.freeze(metadata);
   record.getMetadata = function () {
-    return metadata;
+    return record.xata;
   };
 
   record.toSerializable = function () {
@@ -2028,7 +2028,7 @@ export const initObject = <T>(
     return JSON.stringify(transformObjectLinks(serializable));
   };
 
-  for (const prop of ['read', 'update', 'replace', 'delete', 'xata', 'getMetadata', 'toSerializable', 'toString']) {
+  for (const prop of ['read', 'update', 'replace', 'delete', 'getMetadata', 'toSerializable', 'toString']) {
     Object.defineProperty(record, prop, { enumerable: false });
   }
 

--- a/test/integration/create.test.ts
+++ b/test/integration/create.test.ts
@@ -136,6 +136,10 @@ describe('record creation', () => {
     expect(user.full_name).toBe(apiUser.full_name);
     expect(user.email).toBe(apiUser.email);
 
+    expect(user.xata.createdAt).toBeInstanceOf(Date);
+    expect(apiUser.xata.createdAt).toBeInstanceOf(Date);
+    expect(user.xata.createdAt.getTime()).toBe(apiUser.xata.createdAt.getTime());
+
     expect(
       xata.db.users.create('a-unique-record-john-4', {
         full_name: 'John Doe 5',

--- a/test/integration/read.test.ts
+++ b/test/integration/read.test.ts
@@ -35,9 +35,11 @@ describe('record read', () => {
 
     expect(copy).toBeDefined();
     expect(copy?.id).toBe(team.id);
+    expect(copy?.xata.createdAt).toBeInstanceOf(Date);
 
     expect(definedCopy).toBeDefined();
     expect(definedCopy.id).toBe(team.id);
+    expect(definedCopy.xata.createdAt).toBeInstanceOf(Date);
   });
 
   test('read multiple teams ', async () => {


### PR DESCRIPTION
- Make sure it's enumerable (so it appears on console.log and object cloning)
- Freeze the object
- Add more tests

Fixes #1027 