### PR TITLE
Bugfix: xata init warnings

### DIFF
--- a/.changeset/grumpy-pianos-nail.md
+++ b/.changeset/grumpy-pianos-nail.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+Bugfix: xata init warnings messages fixed

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -179,9 +179,6 @@ export default class Init extends BaseCommand<typeof Init> {
             'xata init --force'
           )}`
         );
-        this.warn('pnpm init');
-        this.warn('yarn init && yarn add @xata.io/client');
-        this.warn('npm init && npm --save @xata.io/client');
       } else if (!isSchemaSetup) {
         this.info(
           `Setup ${


### PR DESCRIPTION
Before: 
```
Generated Xata code to ./src/xata.ts

✔ Project setup with Xata 🦋

 ›   Warning: No package.json found. Please run one of: pnpm init, yarn init, npm init. Then rerun xata init --force
 ›   Warning: pnpm init
 ›   Warning: yarn init && yarn add @xata.io/client
 ›   Warning: npm init && npm --save @xata.io/client
 ```
 
 After:
 
 ```
 Generated Xata code to ./src/xata.ts

✔ Project setup with Xata 🦋

 ›   Warning: No package.json found. Please run one of: pnpm init, yarn init, npm init. Then rerun xata init --force
 ```