### PR TITLE
Allow raw response

### DIFF
--- a/packages/client/src/api/fetcher.ts
+++ b/packages/client/src/api/fetcher.ts
@@ -1,6 +1,6 @@
 import { TraceAttributes, TraceFunction } from '../schema/tracing';
 import { ApiRequestPool, FetchImpl } from '../util/fetch';
-import { compact, isDefined, isString } from '../util/lang';
+import { compact, compactObject, isDefined, isString } from '../util/lang';
 import { fetchEventSource } from '../util/sse';
 import { generateUUID } from '../util/uuid';
 import { VERSION } from '../version';
@@ -46,6 +46,8 @@ export type FetcherExtraProps = {
   clientName?: string;
   xataAgentExtra?: Record<string, string>;
   fetchOptions?: Record<string, unknown>;
+  rawResponse?: boolean;
+  headers?: Record<string, unknown>;
 };
 
 export type ErrorWrapper<TError> = TError | { status: 'unknown'; payload: string };
@@ -96,6 +98,17 @@ function hostHeader(url: string): { Host?: string } {
   return groups?.host ? { Host: groups.host } : {};
 }
 
+function parseBody<T>(body?: T, headers?: Record<string, unknown>): any {
+  if (!isDefined(body)) return undefined;
+
+  const { 'Content-Type': contentType } = headers ?? {};
+  if (String(contentType).toLowerCase() === 'application/json') {
+    return JSON.stringify(body);
+  }
+
+  return body;
+}
+
 const defaultClientID = generateUUID();
 
 export async function fetch<
@@ -123,7 +136,8 @@ export async function fetch<
   sessionID,
   clientName,
   xataAgentExtra,
-  fetchOptions = {}
+  fetchOptions = {},
+  rawResponse = false
 }: FetcherOptions<TBody, THeaders, TQueryParams, TPathParams> & FetcherExtraProps): Promise<TData> {
   pool.setFetch(fetch);
 
@@ -150,7 +164,7 @@ export async function fetch<
         .map(([key, value]) => `${key}=${value}`)
         .join('; ');
 
-      const headers = {
+      const headers = compactObject({
         'Accept-Encoding': 'identity',
         'Content-Type': 'application/json',
         'X-Xata-Client-ID': clientID ?? defaultClientID,
@@ -159,12 +173,12 @@ export async function fetch<
         ...customHeaders,
         ...hostHeader(fullUrl),
         Authorization: `Bearer ${apiKey}`
-      };
+      });
 
       const response = await pool.request(url, {
         ...fetchOptions,
         method: method.toUpperCase(),
-        body: body ? JSON.stringify(body) : undefined,
+        body: parseBody(body, headers),
         headers,
         signal
       });
@@ -193,7 +207,7 @@ export async function fetch<
       }
 
       try {
-        const jsonResponse = await response.json();
+        const jsonResponse = rawResponse ? await response.blob() : await response.json();
 
         if (response.ok) {
           return jsonResponse;

--- a/packages/client/src/util/fetch.ts
+++ b/packages/client/src/util/fetch.ts
@@ -1,11 +1,13 @@
 import { parseNumber, timeout } from './lang';
 
-export type RequestInit = { body?: string; headers?: Record<string, string>; method?: string; signal?: any };
+export type RequestInit = { body?: any; headers?: Record<string, string>; method?: string; signal?: any };
 export type Response = {
   ok: boolean;
   status: number;
   url: string;
   json(): Promise<any>;
+  text(): Promise<string>;
+  blob(): Promise<Blob>;
   headers?: {
     get(name: string): string | null;
   };


### PR DESCRIPTION
For some new endpoints we will support receiving responses that are not JSON, like Blobs. Also expose headers in the options (it was already being parsed but not on the type).
