### PR TITLE
Fix xata init typos

### DIFF
--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -90,7 +90,7 @@ export default class Init extends BaseCommand<typeof Init> {
       options: moduleTypeOptions
     }),
     declarations: Flags.boolean({
-      description: 'Whether or not to generate type declarations for JavaScript code geneartion'
+      description: 'Whether or not to generate type declarations for JavaScript code generation'
     }),
     schema: Flags.string({
       description: 'Initializes a new database or updates an existing one with the given schema'

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -118,7 +118,7 @@ export default class Init extends BaseCommand<typeof Init> {
         );
       } else {
         this.warn(`Will overwrite ${this.projectConfigLocation} because ${chalk.bold('--force')} is being used`);
-        // Clean up the project ocnfiugration so the user is asked for workspace and database again
+        // Clean up the project configuration so the user is asked for workspace and database again
         this.projectConfig = undefined;
       }
     }


### PR DESCRIPTION
This PR fixes a few typos I noticed when reading through the init command code.