### PR TITLE
Change schema upload description

### DIFF
--- a/.changeset/tasty-lies-shout.md
+++ b/.changeset/tasty-lies-shout.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+Change schema upload description

--- a/cli/src/commands/schema/upload.ts
+++ b/cli/src/commands/schema/upload.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises';
 import { BaseCommand } from '../../base.js';
 
 export default class UploadSchema extends BaseCommand<typeof UploadSchema> {
-  static description = 'Edit the schema of the current database';
+  static description = 'Apply a schema to the current database from file';
 
   static examples = [];
 


### PR DESCRIPTION
The schema upload description was the same with schema edit.

This updated message should help make the purpose of `upload` more clear.