### PR TITLE
Tweak rate limiting message

### DIFF
--- a/packages/client/src/util/fetch.ts
+++ b/packages/client/src/util/fetch.ts
@@ -80,7 +80,7 @@ export class ApiRequestPool {
 
       if (stalled) {
         const stalledTime = new Date().getTime() - start.getTime();
-        console.warn(`A request to Xata hit your workspace limits, was retried and stalled for ${stalledTime}ms`);
+        console.warn(`A request to Xata hit branch rate limits, was retried and stalled for ${stalledTime}ms`);
       }
 
       return response;


### PR DESCRIPTION
Adjusts the rate limiting error message. Since rate limits apply at the branch level, referring to workspace limits might be interpreted, as if some API was rate limited at the workspace level which can lead to confusion.