### PR TITLE
fix: double message

### DIFF
--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -159,10 +159,9 @@ export default class Init extends BaseCommand<typeof Init> {
     }
 
     // Run pull to retrieve remote migrations, remove any local migrations, and generate code
-    const result = await Pull.run([branch, '-f']);
-    if (!result?.codegenComplete) {
-      await Codegen.runIfConfigured(this.projectConfig);
-    }
+    await Pull.run([branch, '-f', '-s']);
+    await Codegen.runIfConfigured(this.projectConfig);
+
     await this.delay(1000);
 
     this.log();

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -159,8 +159,10 @@ export default class Init extends BaseCommand<typeof Init> {
     }
 
     // Run pull to retrieve remote migrations, remove any local migrations, and generate code
-    await Pull.run([branch, '-f']);
-    await Codegen.runIfConfigured(this.projectConfig);
+    const result = await Pull.run([branch, '-f']);
+    if (!result?.codegenComplete) {
+      await Codegen.runIfConfigured(this.projectConfig);
+    }
     await this.delay(1000);
 
     this.log();

--- a/cli/src/commands/pull/index.ts
+++ b/cli/src/commands/pull/index.ts
@@ -21,6 +21,11 @@ export default class Pull extends BaseCommand<typeof Pull> {
       char: 'f',
       description: 'Overwrite local migrations',
       default: false
+    }),
+    'skip-code-generation': Flags.boolean({
+      char: 's',
+      description: 'Skip code generation',
+      default: false
     })
   };
 
@@ -64,10 +69,9 @@ export default class Pull extends BaseCommand<typeof Pull> {
 
     this.log(`Successfully pulled ${newMigrations.length} migrations from ${branch} branch`);
 
-    if (this.projectConfig?.codegen) {
+    if (this.projectConfig?.codegen && !flags['skip-code-generation']) {
       this.log(`Running codegen...`);
       await Codegen.run(['--branch', branch]);
-      return { codegenComplete: true };
     }
   }
 

--- a/cli/src/commands/pull/index.ts
+++ b/cli/src/commands/pull/index.ts
@@ -67,6 +67,7 @@ export default class Pull extends BaseCommand<typeof Pull> {
     if (this.projectConfig?.codegen) {
       this.log(`Running codegen...`);
       await Codegen.run(['--branch', branch]);
+      return { codegenComplete: true };
     }
   }
 


### PR DESCRIPTION
This PR prevents the code generation from happening twice when there are migrations to pull by adding a flag to skip code generation to the pull command. It is false by default.

Closes #1103
