### PR TITLE
feat: dynamic branch on init if using default `main` which does not exist

### DIFF
--- a/.changeset/famous-stingrays-stare.md
+++ b/.changeset/famous-stingrays-stare.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Add ability to interactively select branch on xata init when main branch does not exist

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -346,13 +346,24 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     workspace: string,
     region: string,
     database: string,
-    options: { allowEmpty?: boolean; allowCreate?: boolean; title?: string } = {}
+    options: {
+      allowEmpty?: boolean;
+      allowCreate?: boolean;
+      title?: string;
+      checkDefaultExists?: { branch: string };
+    } = {}
   ): Promise<string> {
     const xata = await this.getXataClient();
     const { branches = [] } = await xata.api.branches.getBranchList({ workspace, region, database });
 
     const EMPTY_CHOICE = '$empty';
     const CREATE_CHOICE = '$create';
+
+    if (options.checkDefaultExists) {
+      if (branches.map(({ name }) => name).includes(options.checkDefaultExists.branch)) {
+        return options.checkDefaultExists.branch;
+      }
+    }
 
     if (branches.length > 0) {
       const choices = branches.map((db) => ({

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -350,7 +350,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       allowEmpty?: boolean;
       allowCreate?: boolean;
       title?: string;
-      useBranchIfExists?: { branch: string };
+      // Branch to default if exists
+      defaultBranch?: string;
     } = {}
   ): Promise<string> {
     const xata = await this.getXataClient();
@@ -359,10 +360,8 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     const EMPTY_CHOICE = '$empty';
     const CREATE_CHOICE = '$create';
 
-    if (options.useBranchIfExists) {
-      if (branches.map(({ name }) => name).includes(options.useBranchIfExists.branch)) {
-        return options.useBranchIfExists.branch;
-      }
+    if (options.defaultBranch && branches.map(({ name }) => name).includes(options.defaultBranch)) {
+      return options.defaultBranch;
     }
 
     if (branches.length > 0) {

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -350,7 +350,7 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
       allowEmpty?: boolean;
       allowCreate?: boolean;
       title?: string;
-      checkDefaultExists?: { branch: string };
+      useBranchIfExists?: { branch: string };
     } = {}
   ): Promise<string> {
     const xata = await this.getXataClient();
@@ -359,9 +359,9 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
     const EMPTY_CHOICE = '$empty';
     const CREATE_CHOICE = '$create';
 
-    if (options.checkDefaultExists) {
-      if (branches.map(({ name }) => name).includes(options.checkDefaultExists.branch)) {
-        return options.checkDefaultExists.branch;
+    if (options.useBranchIfExists) {
+      if (branches.map(({ name }) => name).includes(options.useBranchIfExists.branch)) {
+        return options.useBranchIfExists.branch;
       }
     }
 

--- a/cli/src/commands/codegen/index.ts
+++ b/cli/src/commands/codegen/index.ts
@@ -122,7 +122,7 @@ export default class Codegen extends BaseCommand<typeof Codegen> {
     this.log(`Generated Xata code to ./${relative(process.cwd(), output)}`);
   }
 
-  static async runIfConfigured(projectConfig?: ProjectConfig) {
-    if (projectConfig?.codegen?.output) return Codegen.run([]);
+  static async runIfConfigured(projectConfig?: ProjectConfig, flags?: any[]) {
+    if (projectConfig?.codegen?.output) return Codegen.run(flags ?? []);
   }
 }

--- a/cli/src/commands/init/index.test.ts
+++ b/cli/src/commands/init/index.test.ts
@@ -58,8 +58,16 @@ const fetchImplementation = (url: string, request: any) => {
       ok: true,
       json: async () => ({ meta: { cursor: '', more: false }, logs: [] })
     };
+  } else if (url === `https://test-1234.${REGION}.xata.sh/dbs/db1` && request.method === 'GET') {
+    return {
+      ok: true,
+      json: async () => {
+        return {
+          branches: [{ name: 'main', id: 'main' }]
+        };
+      }
+    };
   }
-
   throw new Error(`Unexpected fetch request: ${url} ${request.method}`);
 };
 

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -45,6 +45,8 @@ const packageManagers = {
   }
 };
 
+const defaultBranch = 'main';
+
 const isPackageManagerInstalled = (packageManager: PackageManager) =>
   which.sync(packageManager.command, { nothrow: true });
 
@@ -134,6 +136,18 @@ export default class Init extends BaseCommand<typeof Init> {
 
     const { workspace, region, database, databaseURL } = await this.getParsedDatabaseURL(flags.db, true);
 
+    let branch = this.getCurrentBranchName();
+
+    if (defaultBranch === branch) {
+      branch = await this.getBranch(workspace, region, database, {
+        allowCreate: false,
+        allowEmpty: false,
+        checkDefaultExists: {
+          branch: defaultBranch
+        }
+      });
+    }
+
     this.projectConfig = { databaseURL };
     const ignoreEnvFile = await this.promptIgnoreEnvFile();
 
@@ -146,7 +160,7 @@ export default class Init extends BaseCommand<typeof Init> {
     await this.writeConfig();
     this.log();
 
-    await this.writeEnvFile(workspace, region, database);
+    await this.writeEnvFile(workspace, region, database, branch);
 
     if (ignoreEnvFile) {
       await this.ignoreEnvFile();
@@ -157,39 +171,13 @@ export default class Init extends BaseCommand<typeof Init> {
       await this.installPackage(packageManager, '@xata.io/client');
     }
 
-    let branch = this.getCurrentBranchName();
-
-    if (branch === 'main') {
-      const xataClient = await this.getXataClient();
-      const branches = await xataClient.api.branches.getBranchList({
-        database,
-        region,
-        workspace
-      });
-      if (branches.branches.length === 0) {
-        return this.error('No branches found, please create one first');
-      } else if (!branches.branches.map(({ name }) => name).includes('main')) {
-        if (branches.branches.length === 1) {
-          branch = branches.branches[0].name;
-        } else {
-          const { branchToUse } = await this.prompt({
-            type: 'select',
-            name: 'branchToUse',
-            message: 'Select the branch you would like to use',
-            choices: branches.branches.map(({ name }) => ({ title: name, value: name }))
-          });
-          branch = branchToUse;
-        }
-      }
-    }
-
     if (schema) {
       await this.deploySchema(workspace, region, database, branch, schema);
     }
 
     // Run pull to retrieve remote migrations, remove any local migrations, and generate code
     await Pull.run([branch, '-f', '--skip-code-generation']);
-    await Codegen.runIfConfigured(this.projectConfig);
+    await Codegen.runIfConfigured(this.projectConfig, [`--branch=${branch}`]);
 
     await this.delay(1000);
 
@@ -219,7 +207,7 @@ export default class Init extends BaseCommand<typeof Init> {
           }columns at https://app.xata.io/workspaces/${workspace}/dbs/${database}:${region}`
         );
         this.log();
-        this.info(`Use ${chalk.bold(`xata pull main`)} to regenerate code and types from your Xata database`);
+        this.info(`Use ${chalk.bold(`xata pull ${branch}`)} to regenerate code and types from your Xata database`);
       } else {
         this.log(`To make your first query:`);
         this.log(``);
@@ -400,7 +388,7 @@ export default class Init extends BaseCommand<typeof Init> {
     return envFile;
   }
 
-  async writeEnvFile(workspace: string, region: string, database: string) {
+  async writeEnvFile(workspace: string, region: string, database: string, branch: string) {
     const envFile = await this.findEnvFile();
     const doesEnvFileExist = await this.access(envFile);
 
@@ -423,7 +411,7 @@ export default class Init extends BaseCommand<typeof Init> {
     if (containsXataApiKey) {
       this.warn(`Your ${envFile} file already contains XATA_API_KEY key. skipping...`);
     } else {
-      const setBranch = `XATA_BRANCH=main`;
+      const setBranch = `XATA_BRANCH=${branch}`;
       if (content) content += '\n\n';
       content += '# [Xata] Configuration used by the CLI and the SDK\n';
       content += '# Make sure your framework/tooling loads this file on startup to have it available for the SDK\n';

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -1,5 +1,5 @@
 import { Flags } from '@oclif/core';
-import { buildProviderString, Schemas, XataApiClient } from '@xata.io/client';
+import { buildProviderString, Schemas } from '@xata.io/client';
 import { ModuleType, parseSchemaFile } from '@xata.io/codegen';
 import chalk from 'chalk';
 import dotenv from 'dotenv';

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -45,7 +45,7 @@ const packageManagers = {
   }
 };
 
-const defaultBranch = 'main';
+const DEFAULT_BRANCH = 'main';
 
 const isPackageManagerInstalled = (packageManager: PackageManager) =>
   which.sync(packageManager.command, { nothrow: true });
@@ -136,17 +136,15 @@ export default class Init extends BaseCommand<typeof Init> {
 
     const { workspace, region, database, databaseURL } = await this.getParsedDatabaseURL(flags.db, true);
 
-    let branch = this.getCurrentBranchName();
-
-    if (defaultBranch === branch) {
-      branch = await this.getBranch(workspace, region, database, {
-        allowCreate: false,
-        allowEmpty: false,
-        useBranchIfExists: {
-          branch: defaultBranch
-        }
-      });
-    }
+    const detectedBranch = this.getCurrentBranchName();
+    const branch =
+      detectedBranch === DEFAULT_BRANCH
+        ? await this.getBranch(workspace, region, database, {
+            allowCreate: false,
+            allowEmpty: false,
+            defaultBranch: DEFAULT_BRANCH
+          })
+        : detectedBranch;
 
     this.projectConfig = { databaseURL };
     const ignoreEnvFile = await this.promptIgnoreEnvFile();

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -142,7 +142,7 @@ export default class Init extends BaseCommand<typeof Init> {
       branch = await this.getBranch(workspace, region, database, {
         allowCreate: false,
         allowEmpty: false,
-        checkDefaultExists: {
+        useBranchIfExists: {
           branch: defaultBranch
         }
       });


### PR DESCRIPTION
This PR adds the ability for the user to interactively select the branch they want to use if they are using the default `main` and that does not actually exist (during `xata init`)

If there are no branches for a database an error will be returned (not sure how one would get to this state).


Closes #1095
