### PR TITLE
Increase pagination limits

### DIFF
--- a/packages/client/src/schema/pagination.ts
+++ b/packages/client/src/schema/pagination.ts
@@ -89,9 +89,9 @@ export class Page<Record extends XataRecord, Result extends XataRecord = Record>
 export type CursorNavigationOptions = { start?: string } | { end?: string } | { after?: string; before?: string };
 export type OffsetNavigationOptions = { size?: number; offset?: number };
 
-export const PAGINATION_MAX_SIZE = 200;
+export const PAGINATION_MAX_SIZE = 1000;
 export const PAGINATION_DEFAULT_SIZE = 20;
-export const PAGINATION_MAX_OFFSET = 800;
+export const PAGINATION_MAX_OFFSET = 49000;
 export const PAGINATION_DEFAULT_OFFSET = 0;
 
 export function isCursorPaginationOptions(

--- a/test/integration/query.test.ts
+++ b/test/integration/query.test.ts
@@ -595,14 +595,14 @@ describe('integration tests', () => {
   test('Pagination size limit', async () => {
     expect(xata.db.users.getPaginated({ pagination: { size: PAGINATION_MAX_SIZE + 1 } })).rejects.toHaveProperty(
       'message',
-      'page size exceeds max limit of 200'
+      'page size exceeds max limit of 1000'
     );
   });
 
   test('Pagination offset limit', async () => {
     expect(xata.db.users.getPaginated({ pagination: { offset: PAGINATION_MAX_OFFSET + 1 } })).rejects.toHaveProperty(
       'message',
-      'page offset must not exceed 800'
+      'page offset must not exceed 49000'
     );
   });
 


### PR DESCRIPTION
I've merged earlier today https://github.com/xataio/xata/pull/3117 which significantly increases the pagination limits:

* max page size from 200 to 1000
* max offset from 800 to 49000 (for a total of 50k)

e2e tests failed on staging and it makes sense because the client / e2e tests expected the old limits. I think this should fix it, but I didn't try it yet. I'll try running the tests against staging.
