### PR TITLE
Make `branch create` default to branch from `main`

### DIFF
--- a/.changeset/light-fishes-hide.md
+++ b/.changeset/light-fishes-hide.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+Make `branch create` default to branch from `main`

--- a/cli/src/commands/branch/create.ts
+++ b/cli/src/commands/branch/create.ts
@@ -10,7 +10,8 @@ export default class BranchCreate extends BaseCommand<typeof BranchCreate> {
     ...this.commonFlags,
     ...this.databaseURLFlag,
     from: Flags.string({
-      description: 'Branch name to branch off from'
+      description: 'Branch name to branch off from',
+      default: 'main'
     })
   };
 


### PR DESCRIPTION
Make the `xata branch create` command take a default value of `'main'` for the value of the `--from` flag so that it behaves as described in the [documentation](https://xata.io/docs/getting-started/workflow#initialize-xata-and-create-a-branch).

Fixes #1185 