### PR TITLE
fix: excessive depth on summarize

### DIFF
--- a/.changeset/sixty-steaks-repeat.md
+++ b/.changeset/sixty-steaks-repeat.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Fix excessive depth on summarize

--- a/packages/client/src/schema/selection.ts
+++ b/packages/client/src/schema/selection.ts
@@ -95,7 +95,9 @@ export type SelectedPick<O extends XataRecord, Key extends SelectableColumnWithO
   >;
 
 // Public: Utility type to get the value of a column at a given path
-export type ValueAtColumn<Object, Key> = Key extends '*'
+export type ValueAtColumn<Object, Key, RecursivePath extends any[] = []> = RecursivePath['length'] extends MAX_RECURSION
+  ? never
+  : Key extends '*'
   ? Values<Object> // Alias for any property
   : Key extends 'id'
   ? string // Alias for id (not in schema)
@@ -113,7 +115,7 @@ export type ValueAtColumn<Object, Key> = Key extends '*'
         NonNullable<Object[K]> extends infer Item
           ? Item extends Record<string, any>
             ? V extends SelectableColumn<Item>
-              ? { V: ValueAtColumn<Item, V> }
+              ? { V: ValueAtColumn<Item, V, [...RecursivePath, Item]> }
               : never
             : Object[K]
           : never


### PR DESCRIPTION
This PR gets rid of the `Type instantiation is excessively deep and possibly infinite` type error on summarize 

Resolves #1233