### PR TITLE
CLI import: Added encoding flag

### DIFF
--- a/.changeset/nervous-peas-think.md
+++ b/.changeset/nervous-peas-think.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/cli": patch
+---
+
+CLI import: Added encoding flag, switch to utf8 by default. Fixes some obscure encoding issues.


### PR DESCRIPTION
Fixes: https://github.com/xataio/client-ts/issues/1256

Some files were not being imported properly via the CLI.

Here is an example file: https://github.com/xataio/file-import-samples/blob/main/samples/encoding2.csv provided by @kostasb it contains lots of non-ascii characters.

To fix the issue I've defaulted the encoding node uses to read files to `utf8`. Users can also explicitly specify the encoding. 

## Testing

`xatadevbuild import csv ~/Workspace/xata/file-import-samples/generatedSamples/large1M.csv --create --table repro1` still works as expected.

`xatadevbuild import csv ~/Workspace/xata/file-import-samples/samples/encoding2.csv --create --table repro1` was broken -> now fixed.