### PR TITLE
Handle error from API on search e2e tests

### DIFF
--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -365,7 +365,13 @@ async function waitForSearchIndexing(): Promise<void> {
       return waitForSearchIndexing();
     }
   } catch (error) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    return waitForSearchIndexing();
+    if (isHttpError(error) && !String(error.status).startsWith('4')) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
   }
+}
+
+function isHttpError(error: any): error is Error & { status?: number } {
+  return typeof error === 'object' && typeof error.status === 'number';
 }

--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -358,8 +358,13 @@ describe(
 );
 
 async function waitForSearchIndexing(): Promise<void> {
-  const { aggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
-  if (aggs.total !== teams.length) {
+  try {
+    const { aggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
+    if (aggs.total !== teams.length) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
+  } catch (error) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     return waitForSearchIndexing();
   }

--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -360,16 +360,16 @@ describe(
 async function waitForSearchIndexing(): Promise<void> {
   try {
     const { aggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
-    if (aggs.total !== teams.length) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (aggs.total === teams.length) {
+      return;
     }
   } catch (error) {
-    if (isHttpError(error) && !String(error.status).startsWith('4')) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (isHttpError(error) && String(error.status).startsWith('5')) {
+      throw error;
     }
   }
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return waitForSearchIndexing();
 }
 
 function isHttpError(error: any): error is Error & { status?: number } {

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -269,7 +269,13 @@ async function waitForSearchIndexing(): Promise<void> {
       return waitForSearchIndexing();
     }
   } catch (error) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    return waitForSearchIndexing();
+    if (isHttpError(error) && !String(error.status).startsWith('4')) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
   }
+}
+
+function isHttpError(error: any): error is Error & { status?: number } {
+  return typeof error === 'object' && typeof error.status === 'number';
 }

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -264,16 +264,16 @@ async function waitForSearchIndexing(): Promise<void> {
   try {
     const { aggs: teamAggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
     const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
-    if (teams === undefined || teamAggs.total !== teams.length || userAggs.total !== users.length) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (teams !== undefined && teamAggs.total === teams.length && userAggs.total === users.length) {
+      return;
     }
   } catch (error) {
-    if (isHttpError(error) && !String(error.status).startsWith('4')) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (isHttpError(error) && String(error.status).startsWith('5')) {
+      throw error;
     }
   }
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return waitForSearchIndexing();
 }
 
 function isHttpError(error: any): error is Error & { status?: number } {

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -261,9 +261,14 @@ describe(
 );
 
 async function waitForSearchIndexing(): Promise<void> {
-  const { aggs: teamAggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
-  const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
-  if (teams === undefined || teamAggs.total !== teams.length || userAggs.total !== users.length) {
+  try {
+    const { aggs: teamAggs } = await xata.db.teams.aggregate({ total: { count: '*' } });
+    const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
+    if (teams === undefined || teamAggs.total !== teams.length || userAggs.total !== users.length) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
+  } catch (error) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     return waitForSearchIndexing();
   }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -119,7 +119,13 @@ async function waitForSearchIndexing(): Promise<void> {
       return waitForSearchIndexing();
     }
   } catch (error) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    return waitForSearchIndexing();
+    if (isHttpError(error) && !String(error.status).startsWith('5')) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
   }
+}
+
+function isHttpError(error: any): error is Error & { status?: number } {
+  return typeof error === 'object' && typeof error.status === 'number';
 }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -112,8 +112,13 @@ describe(
 );
 
 async function waitForSearchIndexing(): Promise<void> {
-  const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
-  if (userAggs.total !== users.length) {
+  try {
+    const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
+    if (userAggs.total !== users.length) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      return waitForSearchIndexing();
+    }
+  } catch (error) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     return waitForSearchIndexing();
   }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -114,16 +114,16 @@ describe(
 async function waitForSearchIndexing(): Promise<void> {
   try {
     const { aggs: userAggs } = await xata.db.users.aggregate({ total: { count: '*' } });
-    if (userAggs.total !== users.length) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (userAggs.total === users.length) {
+      return;
     }
   } catch (error) {
-    if (isHttpError(error) && !String(error.status).startsWith('5')) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
-      return waitForSearchIndexing();
+    if (isHttpError(error) && String(error.status).startsWith('5')) {
+      throw error;
     }
   }
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  return waitForSearchIndexing();
 }
 
 function isHttpError(error: any): error is Error & { status?: number } {


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

The aggregate endpoint can now return a 404 if the underlying opensearch schema doesn't exist. This can happen if the table is created and immediately queried, since it needs time to replicate through pgstream. 
This PR adds a try/catch to make sure errors returned from the API don't stop the indexing wait loop.
