### PR TITLE
Catch all errors in search tests indexing loop

### DIFF
--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -364,14 +364,8 @@ async function waitForSearchIndexing(): Promise<void> {
       return;
     }
   } catch (error) {
-    if (isHttpError(error) && String(error.status).startsWith('5')) {
-      throw error;
-    }
+    // do nothing
   }
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return waitForSearchIndexing();
-}
-
-function isHttpError(error: any): error is Error & { status?: number } {
-  return typeof error === 'object' && typeof error.status === 'number';
 }

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -268,14 +268,8 @@ async function waitForSearchIndexing(): Promise<void> {
       return;
     }
   } catch (error) {
-    if (isHttpError(error) && String(error.status).startsWith('5')) {
-      throw error;
-    }
+    // do nothing
   }
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return waitForSearchIndexing();
-}
-
-function isHttpError(error: any): error is Error & { status?: number } {
-  return typeof error === 'object' && typeof error.status === 'number';
 }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -118,14 +118,8 @@ async function waitForSearchIndexing(): Promise<void> {
       return;
     }
   } catch (error) {
-    if (isHttpError(error) && String(error.status).startsWith('5')) {
-      throw error;
-    }
+    // do nothing
   }
   await new Promise((resolve) => setTimeout(resolve, 2000));
   return waitForSearchIndexing();
-}
-
-function isHttpError(error: any): error is Error & { status?: number } {
-  return typeof error === 'object' && typeof error.status === 'number';
 }


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

The tests are still failing since the error returned is internal (500). This PR removes the check in the catch so that all errors trigger a retry.