### PR TITLE
Increase time until next retry for search tests data indexing

### DIFF
--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -366,6 +366,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  await new Promise((resolve) => setTimeout(resolve, 5000));
   return waitForSearchIndexing();
 }

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -270,6 +270,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  await new Promise((resolve) => setTimeout(resolve, 5000));
   return waitForSearchIndexing();
 }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -120,6 +120,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  await new Promise((resolve) => setTimeout(resolve, 5000));
   return waitForSearchIndexing();
 }


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

Since enabling pgstream reads the e2e search tests have started timing out (hitting branch limits) for us-east-1 region. This is likely caused by the indexing taking some time, so this PR increases the sleep between retries for data indexing.