### PR TITLE
Increase sleep between data indexing retries

### DIFF
--- a/test/integration/aggregate.test.ts
+++ b/test/integration/aggregate.test.ts
@@ -366,6 +366,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await new Promise((resolve) => setTimeout(resolve, 8000));
   return waitForSearchIndexing();
 }

--- a/test/integration/search.test.ts
+++ b/test/integration/search.test.ts
@@ -270,6 +270,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await new Promise((resolve) => setTimeout(resolve, 8000));
   return waitForSearchIndexing();
 }

--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -120,6 +120,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 5000));
+  await new Promise((resolve) => setTimeout(resolve, 8000));
   return waitForSearchIndexing();
 }


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

There are still some error failures due to the test branches hitting the limits caused by too many retries. This PR increases the sleep in between tries a bit further (from 5s to 8s).