### PR TITLE
Increase further the indexing loop sleep for vector search tests

### DIFF
--- a/test/integration/vectorSearch.test.ts
+++ b/test/integration/vectorSearch.test.ts
@@ -120,6 +120,6 @@ async function waitForSearchIndexing(): Promise<void> {
   } catch (error) {
     // do nothing
   }
-  await new Promise((resolve) => setTimeout(resolve, 8000));
+  await new Promise((resolve) => setTimeout(resolve, 10000));
   return waitForSearchIndexing();
 }


### PR DESCRIPTION
<!-- Add a nice description here -->

<!-- Don't forget the `Closed #{issue_number}` -->

Vector search tests seem to be the ones more affected by the branch limits. Increase the sleep further.