### PR TITLE
Add workflow to publish next releases on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,15 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Update next channel
+        if: github.ref_name == 'next'
+        run: |
+          npx changeset version
+          npx changeset publish
+
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1
+        if: github.ref_name == 'main'
         with:
           title: Release tracking
           publish: npx changeset publish

--- a/.github/workflows/update-next.yml
+++ b/.github/workflows/update-next.yml
@@ -1,0 +1,26 @@
+name: Update next branch with latest main
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  update-next:
+    name: Update next branch with latest main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure
+        run: |
+          git config user.email "system@xata.io"
+          git config user.name "Xata"
+
+      - name: Rebase next branch with latest main
+        run: |
+          git checkout next
+          git rebase main
+          git push origin next

--- a/scripts/changeset-version.mjs
+++ b/scripts/changeset-version.mjs
@@ -6,6 +6,13 @@ import { execSync } from 'child_process';
 // Run "npx changeset version" to update the versions in the monorepo
 execSync('npx changeset version', { stdio: 'inherit' });
 
+// Check if we're on the main branch, if not, skip updating compatibility.json
+const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+if (branch !== 'main') {
+  console.log('Not on master, skipping compatibility.json update');
+  process.exit(0);
+}
+
 const compatibilityPath = path.join(process.cwd(), 'compatibility.json');
 const compatibilityData = fs.readFileSync(compatibilityPath, 'utf8');
 const compatibility = JSON.parse(compatibilityData);

--- a/scripts/changeset-version.mjs
+++ b/scripts/changeset-version.mjs
@@ -6,13 +6,6 @@ import { execSync } from 'child_process';
 // Run "npx changeset version" to update the versions in the monorepo
 execSync('npx changeset version', { stdio: 'inherit' });
 
-// Check if we're on the main branch, if not, skip updating compatibility.json
-const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
-if (branch !== 'main') {
-  console.log('Not on master, skipping compatibility.json update');
-  process.exit(0);
-}
-
 const compatibilityPath = path.join(process.cwd(), 'compatibility.json');
 const compatibilityData = fs.readFileSync(compatibilityPath, 'utf8');
 const compatibility = JSON.parse(compatibilityData);


### PR DESCRIPTION
- Publish pre releases to npm (see: https://github.com/xataio/client-ts/blob/next/.changeset/pre.json)
- Add a GitHub Action to attempt rebase main onto next (if there are conflicts we will need to manually rebase, but I think that's fine)
- Don't update compatibility json with next changes