### PR TITLE
Add CLI support for running against local development environments

### DIFF
--- a/.changeset/cuddly-walls-sniff.md
+++ b/.changeset/cuddly-walls-sniff.md
@@ -1,0 +1,6 @@
+---
+"@xata.io/cli": patch
+"@xata.io/client": patch
+---
+
+Add CLI support for running against local development environments

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -29,7 +29,7 @@ It is possible to run the `xata` CLI against `localhost` (Docker) environments, 
 1. Create a `local` CLI profile
 
 ```
-xata auth login --profile local --host http://localhost:6001,http://08lcul.localhost:6001
+xata auth login --profile local --host http://localhost:6001,http://08lcul.dev.localhost:6001
 ```
 
 where `08lcul` is your local workspace id.

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -32,7 +32,7 @@ It is possible to run the `xata` CLI against `localhost` (Docker) environments, 
 xata auth login --profile local --host http://localhost:6001,http://08lcul.dev.localhost:6001
 ```
 
-where `08lcul` is your local workspace id.
+where `08lcul` is your local workspace id and `dev` is the name of your local region.
 
 2. Initalize the CLI, specifying the `local` profile:
 

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -21,3 +21,21 @@ then: `xatadev status` or `xatadevbuild status`
 To run the CLI against a different profile, you can use:
 
 `./cli/bin/dev.js auth login --profile staging --host staging` where host values can be prod, staging, dev, and controlPlaneUrl, dataPlaneUrl (comma delimited for ephemeral instances or localhost docker)
+
+# Running the CLI against `localhost`
+
+It is possible to run the `xata` CLI against `localhost` (Docker) environments, following these steps:
+
+1. Create a `local` CLI profile
+
+```
+xata auth login --profile local --host http://localhost:6001,http://08lcul.localhost:6001
+```
+
+where `08lcul` is your local workspace id.
+
+2. Initalize the CLI, specifying the `local` profile:
+
+```
+xata init --profile local
+```

--- a/packages/client/src/api/fetcher.ts
+++ b/packages/client/src/api/fetcher.ts
@@ -180,7 +180,9 @@ export async function fetch<
 
       // Node.js on localhost won't resolve localhost subdomains unless mapped in /etc/hosts
       // So, instead, we use localhost without subdomains, but will add a Host header
-      const url = fullUrl.includes('localhost') ? fullUrl.replace(/^[^.]+\./, 'http://') : fullUrl;
+      // We remove two subdomains because we need be able to resolve localhost URLs like
+      // http://ws-id.dev.localhost
+      const url = fullUrl.includes('localhost') ? fullUrl.replace(/^[^.]+\.[^.]+\./, 'http://') : fullUrl;
       setAttributes({
         [TraceAttributes.HTTP_URL]: url,
         [TraceAttributes.HTTP_TARGET]: resolveUrl(path, queryParams, pathParams)

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -63,7 +63,7 @@ export function parseWorkspacesUrlParts(url: string): { workspace: string; regio
     production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh.*/),
     staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev.*/),
     dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev.*/),
-    local: url.match(/(?:https?:\/\/)?([^.]+)\.localhost:(\d+)/)
+    local: url.match(/(?:https?:\/\/)?([^.]+)(?:\.([^.]+))\.localhost:(\d+)/)
   };
 
   const [host, match] = Object.entries(matches).find(([, match]) => match !== null) ?? [];

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -1,6 +1,6 @@
 import { isObject, isString } from '../util/lang';
 
-type HostAliases = 'production' | 'staging' | 'dev';
+type HostAliases = 'production' | 'staging' | 'dev' | 'local';
 type ProviderBuilder = { main: string; workspaces: string };
 export type HostProvider = HostAliases | ProviderBuilder;
 
@@ -26,6 +26,10 @@ const providers: Record<HostAliases, ProviderBuilder> = {
   dev: {
     main: 'https://api.dev-xata.dev',
     workspaces: 'https://{workspaceId}.{region}.dev-xata.dev'
+  },
+  local: {
+    main: 'http://localhost:6001',
+    workspaces: 'http://{workspaceId}.localhost:6001'
   }
 };
 
@@ -58,11 +62,13 @@ export function parseWorkspacesUrlParts(url: string): { workspace: string; regio
   const matches = {
     production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh.*/),
     staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev.*/),
-    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev.*/)
+    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev.*/),
+    local: url.match(/(?:https?:\/\/)?([^.]+)\.localhost:(\d+)/)
   };
 
   const [host, match] = Object.entries(matches).find(([, match]) => match !== null) ?? [];
   if (!isHostProviderAlias(host) || !match) return null;
 
-  return { workspace: match[1], region: match[2], host };
+  const region = host === 'local' ? 'dev' : match[2];
+  return { workspace: match[1], region, host };
 }

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -29,7 +29,7 @@ const providers: Record<HostAliases, ProviderBuilder> = {
   },
   local: {
     main: 'http://localhost:6001',
-    workspaces: 'http://{workspaceId}.localhost:6001'
+    workspaces: 'http://{workspaceId}.{region}.localhost:6001'
   }
 };
 

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -69,6 +69,5 @@ export function parseWorkspacesUrlParts(url: string): { workspace: string; regio
   const [host, match] = Object.entries(matches).find(([, match]) => match !== null) ?? [];
   if (!isHostProviderAlias(host) || !match) return null;
 
-  const region = host === 'local' ? 'dev' : match[2];
-  return { workspace: match[1], region, host };
+  return { workspace: match[1], region: match[2], host };
 }


### PR DESCRIPTION
Support running the `xata` CLI against `localhost` development environments:

* Add regexp and provider for `local` environments.
* Update the `CONTRIBUTING.md` file with instructions.

See [[Slack](https://xata-hq.slack.com/archives/C032EKCBUGM/p1704460179520329)] for more context
