### PR TITLE
Importer: coerce floats to int

### DIFF
--- a/.changeset/bright-donuts-matter.md
+++ b/.changeset/bright-donuts-matter.md
@@ -1,0 +1,5 @@
+---
+"@xata.io/importer": patch
+---
+
+Importer: Allow coerce floats to int

--- a/packages/importer/src/columns.ts
+++ b/packages/importer/src/columns.ts
@@ -157,7 +157,9 @@ export const coerceValue = async (
       return isEmail(value) ? { value: String(value).trim(), isError: false } : { value: null, isError: true };
     }
     case 'int': {
-      return isInteger(value) ? { value: parseInt(String(value), 10), isError: false } : { value: null, isError: true };
+      return isInteger(value) || isFloat(value)
+        ? { value: parseInt(String(value), 10), isError: false }
+        : { value: null, isError: true };
     }
     case 'float': {
       return isFloat(value) ? { value: parseFloat(String(value)), isError: false } : { value: null, isError: true };

--- a/packages/importer/test/columns.test.ts
+++ b/packages/importer/test/columns.test.ts
@@ -282,6 +282,9 @@ const coerceTestCases: {
 }[] = [
   { input: '1', type: 'int', expected: { value: 1, isError: false } },
   { input: ' 1 ', type: 'int', expected: { value: 1, isError: false } },
+  { input: '1.0', type: 'int', expected: { value: 1, isError: false } },
+  { input: '1.123', type: 'int', expected: { value: 1, isError: false } },
+  { input: '-1.123', type: 'int', expected: { value: -1, isError: false } },
   { input: '1', type: 'float', expected: { value: 1.0, isError: false } },
   { input: '1000', type: 'float', expected: { value: 1000, isError: false } },
   { input: '1.1', type: 'float', expected: { value: 1.1, isError: false } },
@@ -785,6 +788,11 @@ const coerceRowsTestCases: {
     rows: [{ col: '1' }, { col: '-2' }],
     columns: [{ name: 'col', type: 'int' }],
     expected: [{ col: { value: 1, isError: false } }, { col: { value: -2, isError: false } }]
+  },
+  {
+    rows: [{ col: '1.1' }, { col: '-1.1' }],
+    columns: [{ name: 'col', type: 'int' }],
+    expected: [{ col: { value: 1, isError: false } }, { col: { value: -1, isError: false } }]
   },
   {
     rows: [{ col: '1.0' }],


### PR DESCRIPTION
<!-- Add a nice description here -->
Float like strings e.g. `"1.1"` can be coerced to ints `1` if the user explicitly requests it
<!-- Don't forget the `Closed #{issue_number}` -->
