### PR TITLE
Take `pgroll` JSON schema from a branch

### DIFF
--- a/packages/pgroll/src/index.ts
+++ b/packages/pgroll/src/index.ts
@@ -2,7 +2,8 @@ import { schema } from './schema';
 
 export * from './types';
 
-export const PGROLL_JSON_SCHEMA_URL = 'https://raw.githubusercontent.com/xataio/pgroll/main/schema.json';
+export const PGROLL_JSON_SCHEMA_URL =
+  'https://raw.githubusercontent.com/xataio/pgroll/alter-column-json-schema/schema.json';
 
 // In the future, we can use this function to generate the JSON schema tailored to the user's data model.
 export function generateJSONSchema() {

--- a/packages/pgroll/src/schema.ts
+++ b/packages/pgroll/src/schema.ts
@@ -60,6 +60,10 @@ export const schema = {
         unique: {
           description: 'Indicates if the column values must be unique',
           type: 'boolean'
+        },
+        comment: {
+          description: 'Postgres comment for the column',
+          type: 'string'
         }
       },
       required: ['name', 'nullable', 'pk', 'type', 'unique'],
@@ -126,7 +130,7 @@ export const schema = {
           type: 'string'
         },
         nullable: {
-          description: 'Indicates if the column is nullable (for add not null constraint operation)',
+          description: 'Indicates if the column is nullable (for add/remove not null constraint operation)',
           type: 'boolean'
         },
         references: {
@@ -150,7 +154,38 @@ export const schema = {
           type: 'string'
         }
       },
-      required: ['column', 'down', 'name', 'table', 'type', 'up'],
+      required: ['table', 'column'],
+      oneOf: [
+        {
+          required: ['name'],
+          not: {
+            required: ['up', 'down']
+          }
+        },
+        {
+          required: ['up', 'down'],
+          oneOf: [
+            {
+              required: ['check']
+            },
+            {
+              required: ['type']
+            },
+            {
+              required: ['nullable']
+            },
+            {
+              required: ['unique']
+            },
+            {
+              required: ['references']
+            }
+          ],
+          not: {
+            required: ['name']
+          }
+        }
+      ],
       type: 'object'
     },
     OpCreateIndex: {
@@ -189,6 +224,10 @@ export const schema = {
         },
         name: {
           description: 'Name of the table',
+          type: 'string'
+        },
+        comment: {
+          description: 'Postgres comment for the table',
           type: 'string'
         }
       },

--- a/packages/pgroll/src/types.ts
+++ b/packages/pgroll/src/types.ts
@@ -25,7 +25,8 @@ export const ColumnDefinition = z.object({
   pk: z.boolean(),
   references: ForeignKeyReferenceDefinition.optional(),
   type: z.string(),
-  unique: z.boolean()
+  unique: z.boolean(),
+  comment: z.string().optional()
 });
 
 export type OpAddColumn = z.infer<typeof OpAddColumnDefinition>;
@@ -45,14 +46,14 @@ export type OpAlterColumn = z.infer<typeof OpAlterColumnDefinition>;
 export const OpAlterColumnDefinition = z.object({
   check: CheckConstraintDefinition.optional(),
   column: z.string(),
-  down: z.string(),
-  name: z.string(),
+  down: z.string().optional(),
+  name: z.string().optional(),
   nullable: z.boolean().optional(),
   references: ForeignKeyReferenceDefinition.optional(),
   table: z.string(),
-  type: z.string(),
+  type: z.string().optional(),
   unique: UniqueConstraintDefinition.optional(),
-  up: z.string()
+  up: z.string().optional()
 });
 
 export type OpCreateIndex = z.infer<typeof OpCreateIndexDefinition>;
@@ -67,7 +68,8 @@ export type OpCreateTable = z.infer<typeof OpCreateTableDefinition>;
 
 export const OpCreateTableDefinition = z.object({
   columns: z.array(ColumnDefinition),
-  name: z.string()
+  name: z.string(),
+  comment: z.string().optional()
 });
 
 export type OpDropColumn = z.infer<typeof OpDropColumnDefinition>;


### PR DESCRIPTION
Update and regenerate the schema JSON for `pgroll` using the `alter-column-json-schema` (https://github.com/xataio/pgroll/pull/261) branch.

https://github.com/xataio/pgroll/pull/261 makes changes to the schema for the 'alter column' operation and it would be good to test them in the migration editor before merge.