### PR TITLE
Add response type array to xata.sql

### DIFF
--- a/.changeset/silly-countries-push.md
+++ b/.changeset/silly-countries-push.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Add support for array response type

--- a/packages/client/src/sql/index.ts
+++ b/packages/client/src/sql/index.ts
@@ -92,7 +92,7 @@ export class SQLPlugin extends XataPlugin {
         throw new Error('Invalid usage of `xata.sql`. Please use it as a tagged template or with an object.');
       }
 
-      const { statement, params, consistency } = prepareParams(query, parameters);
+      const { statement, params, consistency, responseType } = prepareParams(query, parameters);
 
       const {
         records,
@@ -101,7 +101,7 @@ export class SQLPlugin extends XataPlugin {
         columns = []
       } = await sqlQuery({
         pathParams: { workspace: '{workspaceId}', dbBranchName: '{dbBranch}', region: '{region}' },
-        body: { statement, params, consistency },
+        body: { statement, params, consistency, responseType },
         ...pluginOptions
       });
 

--- a/packages/client/src/sql/parameters.ts
+++ b/packages/client/src/sql/parameters.ts
@@ -69,9 +69,9 @@ export function prepareParams(param1: SQLQuery | string, param2?: any[]) {
   }
 
   if (isObject(param1)) {
-    const { statement, params, consistency } = param1;
+    const { statement, params, consistency, responseType } = param1;
 
-    return { statement, params: params?.map((value) => prepareValue(value)), consistency };
+    return { statement, params: params?.map((value) => prepareValue(value)), consistency, responseType };
   }
 
   throw new Error('Invalid query');

--- a/test/integration/sql.test.ts
+++ b/test/integration/sql.test.ts
@@ -288,7 +288,7 @@ describe('SQL proxy', () => {
     expect(records).toBeDefined();
   });
 
-  test("calling xata.sql with response type 'array' returns the correct result", async () => {
+  test.skip("calling xata.sql with response type 'array' returns the correct result", async () => {
     const teams = await xata.db.teams.create([{ name: '[C] Cars' }, { name: '[C] Planes' }]);
 
     const { rows, warning, columns } = await xata.sql({

--- a/test/integration/sql.test.ts
+++ b/test/integration/sql.test.ts
@@ -287,4 +287,89 @@ describe('SQL proxy', () => {
     });
     expect(records).toBeDefined();
   });
+
+  test("calling xata.sql with response type 'array' returns the correct result", async () => {
+    const teams = await xata.db.teams.create([{ name: '[C] Cars' }, { name: '[C] Planes' }]);
+
+    const { rows, warning, columns } = await xata.sql({
+      statement: `SELECT * FROM teams WHERE name LIKE '[C] %'`,
+      responseType: 'array'
+    });
+
+    expect(warning).toBeUndefined();
+    expect(rows).toHaveLength(2);
+
+    expect(columns).toMatchInlineSnapshot(`
+      [
+        {
+          "name": "id",
+          "type": "text",
+        },
+        {
+          "name": "xata.version",
+          "type": "int4",
+        },
+        {
+          "name": "xata.createdAt",
+          "type": "timestamptz",
+        },
+        {
+          "name": "xata.updatedAt",
+          "type": "timestamptz",
+        },
+        {
+          "name": "name",
+          "type": "text",
+        },
+        {
+          "name": "description",
+          "type": "text",
+        },
+        {
+          "name": "labels",
+          "type": "_text",
+        },
+        {
+          "name": "index",
+          "type": "int8",
+        },
+        {
+          "name": "rating",
+          "type": "float8",
+        },
+        {
+          "name": "founded_date",
+          "type": "timestamptz",
+        },
+        {
+          "name": "email",
+          "type": "text",
+        },
+        {
+          "name": "plan",
+          "type": "text",
+        },
+        {
+          "name": "dark",
+          "type": "bool",
+        },
+        {
+          "name": "config",
+          "type": "jsonb",
+        },
+        {
+          "name": "owner",
+          "type": "text",
+        },
+      ]
+    `);
+
+    const record1 = rows.find((row) => row[0] === teams[0].id);
+    const record2 = rows.find((row) => row[0] === teams[1].id);
+
+    expect(record1).toBeDefined();
+    expect(record1?.[4]).toBe('[C] Cars');
+    expect(record2).toBeDefined();
+    expect(record2?.[4]).toBe('[C] Planes');
+  });
 });


### PR DESCRIPTION
Add support for `array` response type, used in several ORMs
