### PR TITLE
Add `xata.sql.connectionString` helper

### DIFF
--- a/.changeset/healthy-mails-drop.md
+++ b/.changeset/healthy-mails-drop.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/client': patch
+---
+
+Expose `xata.sql.connectionString` helper

--- a/cli/src/base.ts
+++ b/cli/src/base.ts
@@ -489,15 +489,15 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
   }
 
   parseDatabaseURL(databaseURL: string) {
-    const [protocol, , host, , database] = databaseURL.split('/');
-    const urlParts = parseWorkspacesUrlParts(host);
+    const [protocol, , host] = databaseURL.split('/');
+    const urlParts = parseWorkspacesUrlParts(databaseURL);
     if (!urlParts) {
       throw new Error(
         `Unable to parse workspace and region in ${databaseURL}. Please check your .xatarc file and re-run codegen before continuing. If don't know how to proceed, please contact us at support@xata.io.`
       );
     }
 
-    const { workspace, region } = urlParts;
+    const { workspace, region, database } = urlParts;
 
     return { databaseURL, protocol, host, database, workspace, region };
   }

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -56,18 +56,20 @@ export function buildProviderString(provider: HostProvider): string {
   return `${provider.main},${provider.workspaces}`;
 }
 
-export function parseWorkspacesUrlParts(url: string): { workspace: string; region: string; host: HostAliases } | null {
+export function parseWorkspacesUrlParts(
+  url: string
+): { workspace: string; region: string; database: string; host: HostAliases } | null {
   if (!isString(url)) return null;
 
   const matches = {
-    production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh.*/),
-    staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev.*/),
-    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev.*/),
+    production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh\/db\/(.*)/),
+    staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev\/db\/(.*)/),
+    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev\/db\/(.*)/),
     local: url.match(/(?:https?:\/\/)?([^.]+)(?:\.([^.]+))\.localhost:(\d+)/)
   };
 
   const [host, match] = Object.entries(matches).find(([, match]) => match !== null) ?? [];
   if (!isHostProviderAlias(host) || !match) return null;
 
-  return { workspace: match[1], region: match[2], host };
+  return { workspace: match[1], region: match[2], database: match[3], host };
 }

--- a/packages/client/src/api/providers.ts
+++ b/packages/client/src/api/providers.ts
@@ -58,18 +58,18 @@ export function buildProviderString(provider: HostProvider): string {
 
 export function parseWorkspacesUrlParts(
   url: string
-): { workspace: string; region: string; database: string; host: HostAliases } | null {
+): { workspace: string; region: string; database: string; branch?: string; host: HostAliases } | null {
   if (!isString(url)) return null;
 
   const matches = {
-    production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh\/db\/(.*)/),
-    staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev\/db\/(.*)/),
-    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev\/db\/(.*)/),
-    local: url.match(/(?:https?:\/\/)?([^.]+)(?:\.([^.]+))\.localhost:(\d+)/)
+    production: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.xata\.sh\/db\/([^:]+):?(.*)?/),
+    staging: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.staging-xata\.dev\/db\/([^:]+):?(.*)?/),
+    dev: url.match(/(?:https:\/\/)?([^.]+)(?:\.([^.]+))\.dev-xata\.dev\/db\/([^:]+):?(.*)?/),
+    local: url.match(/(?:https?:\/\/)?([^.]+)(?:\.([^.]+))\.localhost:([^:]+):?(.*)?/)
   };
 
   const [host, match] = Object.entries(matches).find(([, match]) => match !== null) ?? [];
   if (!isHostProviderAlias(host) || !match) return null;
 
-  return { workspace: match[1], region: match[2], database: match[3], host };
+  return { workspace: match[1], region: match[2], database: match[3], branch: match[4], host };
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -52,7 +52,8 @@ export const buildClient = <Plugins extends Record<string, XataPlugin> = {}>(plu
         ...this.#getFetchProps(safeOptions),
         cache: safeOptions.cache,
         host: safeOptions.host,
-        tables
+        tables,
+        branch: safeOptions.branch
       };
 
       const db = new SchemaPlugin().build(pluginOptions);

--- a/packages/client/src/plugins.ts
+++ b/packages/client/src/plugins.ts
@@ -9,4 +9,5 @@ export type XataPluginOptions = ApiExtraProps & {
   cache: CacheImpl;
   host: HostProvider;
   tables: Schemas.Table[];
+  branch: string;
 };

--- a/packages/client/src/schema/index.test.ts
+++ b/packages/client/src/schema/index.test.ts
@@ -13,7 +13,7 @@ interface User {
 const buildClient = (options: Partial<BaseClientOptions> = {}) => {
   const {
     apiKey = '1234',
-    databaseURL = 'https://mock.xata.sh/db/xata',
+    databaseURL = 'https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb',
     branch = 'main',
     clientName,
     xataAgentExtra
@@ -83,7 +83,7 @@ describe('client options', () => {
       {
         "body": "{"page":{"size":1},"columns":["*"]}",
         "method": "POST",
-        "url": "https://mock.xata.sh/db/xata:branch/tables/users/query",
+        "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:branch/tables/users/query",
       }
     `);
   });
@@ -115,7 +115,7 @@ describe('request', () => {
       {
         "body": "{"page":{"size":1},"columns":["*"]}",
         "method": "POST",
-        "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+        "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
       }
     `);
   });
@@ -145,7 +145,7 @@ describe('request', () => {
       {
         "body": "{"page":{"size":20},"columns":["*"]}",
         "method": "POST",
-        "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+        "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
       }
     `);
   });
@@ -293,7 +293,7 @@ describe('query', () => {
           {
             "body": "{"page":{"size":20},"columns":["*"]}",
             "method": "POST",
-            "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+            "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
           },
         ]
       `);
@@ -313,7 +313,7 @@ describe('query', () => {
           {
             "body": "{"filter":{"$all":[{"name":"foo"}]},"page":{"size":20},"columns":["*"]}",
             "method": "POST",
-            "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+            "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
           },
         ]
       `);
@@ -341,7 +341,7 @@ describe('query', () => {
           {
             "body": "{"page":{"size":1},"columns":["*"]}",
             "method": "POST",
-            "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+            "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
           },
         ]
       `);
@@ -366,7 +366,7 @@ describe('query', () => {
           {
             "body": "{"page":{"size":1},"columns":["*"]}",
             "method": "POST",
-            "url": "https://mock.xata.sh/db/xata:main/tables/users/query",
+            "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/query",
           },
         ]
       `);
@@ -387,7 +387,7 @@ describe('read', () => {
         {
           "body": undefined,
           "method": "GET",
-          "url": "https://mock.xata.sh/db/xata:main/tables/users/data/rec_1234?columns=*",
+          "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/data/rec_1234?columns=*",
         },
       ]
     `);
@@ -405,7 +405,7 @@ describe('read', () => {
         {
           "body": undefined,
           "method": "GET",
-          "url": "https://mock.xata.sh/db/xata:main/tables/users/data/rec_1234?columns=name%2Cage",
+          "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/data/rec_1234?columns=name%2Cage",
         },
       ]
     `);
@@ -436,7 +436,7 @@ describe('Repository.update', () => {
         {
           "body": "{"name":"Ada"}",
           "method": "PATCH",
-          "url": "https://mock.xata.sh/db/xata:main/tables/users/data/rec_1234?columns=*",
+          "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/data/rec_1234?columns=*",
         },
       ]
     `);
@@ -458,7 +458,7 @@ describe('Repository.delete', () => {
         {
           "body": undefined,
           "method": "DELETE",
-          "url": "https://mock.xata.sh/db/xata:main/tables/users/data/rec_1234?columns=*",
+          "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/data/rec_1234?columns=*",
         },
       ]
     `);
@@ -495,7 +495,7 @@ describe('create', () => {
         {
           "body": "{"name":"Ada"}",
           "method": "POST",
-          "url": "https://mock.xata.sh/db/xata:main/tables/users/data?columns=*",
+          "url": "https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb:main/tables/users/data?columns=*",
         },
       ]
     `);

--- a/packages/importer/test/utils.ts
+++ b/packages/importer/test/utils.ts
@@ -22,5 +22,8 @@ export const getXataClientWithPlugin = () => {
     import: new XataImportPlugin()
   });
 
-  return new XataClient({ apiKey: 'xau_test123', databaseURL: 'https://something.com' });
+  return new XataClient({
+    apiKey: 'xau_test123',
+    databaseURL: 'https://my-workspace-v0fo9s.us-east-1.xata.sh/db/mydb'
+  });
 };

--- a/test/integration/sql.test.ts
+++ b/test/integration/sql.test.ts
@@ -287,4 +287,11 @@ describe('SQL proxy', () => {
     });
     expect(records).toBeDefined();
   });
+
+  test('xata.sql has a connection string', async () => {
+    expect(xata.sql.connectionString).toBeDefined();
+    expect(xata.sql.connectionString).toMatch(
+      /postgresql:\/\/([a-z0-9]+):([a-zA-Z0-9_]+)@([a-z0-9-.]+)\/([a-z0-9-]+):([a-z0-9-]+)\?sslmode=require/
+    );
+  });
 });


### PR DESCRIPTION
Example usage:

```ts
import { Client } from 'pg';
import { XataClient } from '@xata.io/client';

const xata = new XataClient();

const client = new Client({
  connectionString: xata.sql.connectionString
});
```