### PR TITLE
Using ENV variables in Codegen

### DIFF
--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -158,7 +158,7 @@ export default class Init extends BaseCommand<typeof Init> {
     await this.writeConfig();
     this.log();
 
-    await this.writeEnvFile(workspace, region, database, branch);
+    await this.writeEnvFile(workspace, region, database, branch, databaseURL);
 
     if (ignoreEnvFile) {
       await this.ignoreEnvFile();
@@ -386,7 +386,7 @@ export default class Init extends BaseCommand<typeof Init> {
     return envFile;
   }
 
-  async writeEnvFile(workspace: string, region: string, database: string, branch: string) {
+  async writeEnvFile(workspace: string, region: string, database: string, branch: string, databaseURL: string) {
     const envFile = await this.findEnvFile();
     const doesEnvFileExist = await this.access(envFile);
 
@@ -415,12 +415,15 @@ export default class Init extends BaseCommand<typeof Init> {
       content += '# Make sure your framework/tooling loads this file on startup to have it available for the SDK\n';
       content += `${setBranch}\n`;
       content += `XATA_API_KEY=${apiKey}\n`;
+      content += `XATA_DATABASE_URL=${databaseURL}`;
       if (profile.host !== 'production') content += `XATA_API_PROVIDER=${buildProviderString(profile.host)}\n`;
 
       this.log(`${doesEnvFileExist ? 'Updating' : 'Creating'} ${envFile} file`);
       await writeFile(envFile, content);
       await this.delay(500);
       this.log(`  set XATA_API_KEY=xau_*********************************`);
+      await this.delay(500);
+      this.log(`  set DATABASE_URL=${databaseURL}\n`);
       await this.delay(500);
       this.log(`  set ${setBranch}\n`);
       await this.delay(500);

--- a/packages/codegen/src/codegen.ts
+++ b/packages/codegen/src/codegen.ts
@@ -44,6 +44,19 @@ function getTypeName(tableName: string) {
   return name;
 }
 
+function getCorrectEnvForModuleType(databaseUrl: string, moduleType?: ModuleType) {
+  switch (moduleType) {
+    case 'cjs':
+      return `process.env.XATA_DATABASE_URL`;
+    case 'deno':
+      return `Deno.env.get('XATA_DATABASE_URL')`;
+    case 'esm':
+      return `import.meta.env.XATA_DATABASE_URL`;
+    default:
+      return `"${databaseUrl}"`;
+  }
+}
+
 export async function generate({
   databaseURL,
   branch,
@@ -226,7 +239,9 @@ export async function generate({
 
   // Add default options
   const defaultOptions = sourceFile.getVariableDeclaration('defaultOptions');
-  const defaultOptionsContent = JSON.stringify({ databaseURL, branch });
+  const defaultOptionsContent = `{
+    databaseURL: ${getCorrectEnvForModuleType(databaseURL, moduleType)}${branch ? `,\nbranch: ${branch}` : ''}
+  }`;
 
   if (!defaultOptions) {
     sourceFile.addVariableStatement({


### PR DESCRIPTION
The intention behind this PR is to try and introduce the ability for the codegen to utilise environment variables rather than a `databaseUrl` string value to make it easier to commit to repositories and setup different environments where necessary.

This PR is still a WIP as there's some things that likely need to be considered about how these environment variables will work in various situations (such as within a Next.js project where they should be prefixed with `NEXT_PUBLIC`).

Closes #1440

