### PR TITLE
feat: add schema param to apply request on push

### DIFF
--- a/cli/src/commands/push/index.ts
+++ b/cli/src/commands/push/index.ts
@@ -105,14 +105,15 @@ export default class Push extends BaseCommand<typeof Push> {
     if (!confirm) return this.exit(1);
 
     if (isBranchPgRollEnabled(details)) {
-      const migrationsToPush = (newMigrations as MigrationFilePgroll[])
-        .map(({ migration }) => migration)
-        .flatMap((migration) => PgRollMigrationDefinition.parse(migration));
+      const migrationsToPush = (newMigrations as MigrationFilePgroll[]).map(({ migration, schema }) => ({
+        operations: PgRollMigrationDefinition.parse(migration),
+        schema
+      }));
       for (const migration of migrationsToPush) {
         try {
           const { jobID } = await xata.api.migrations.applyMigration({
             pathParams: { workspace, region, dbBranchName: `${database}:${branch}` },
-            body: migration
+            body: { ...migration.operations, schema: migration.schema }
           });
 
           await waitForMigrationToFinish(xata.api, workspace, region, database, branch, jobID);

--- a/cli/src/migrations/schema.ts
+++ b/cli/src/migrations/schema.ts
@@ -55,7 +55,8 @@ export const migrationFilePgroll = z.object({
   parent: z.string().optional(),
   migration: PgRollMigrationDefinition,
   done: z.boolean(),
-  migrationType: z.enum(['pgroll', 'inferred']) satisfies z.ZodType<Schemas.MigrationType>
+  migrationType: z.enum(['pgroll', 'inferred']) satisfies z.ZodType<Schemas.MigrationType>,
+  schema: z.string()
 });
 
 export type MigrationFilePgroll = z.infer<typeof migrationFilePgroll>;


### PR DESCRIPTION
This PR adds the migration schema parameter to the apply endpoint. 

No changes to the ordering as push and pull already assume the the history endpoint returns migrations in the order they were executed on the db