### PR TITLE
handle client/next already specified

### DIFF
--- a/.changeset/lucky-tigers-peel.md
+++ b/.changeset/lucky-tigers-peel.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+Fix overriding client version to latest with Postgres branches if next is already a dependency

--- a/cli/src/commands/init/index.ts
+++ b/cli/src/commands/init/index.ts
@@ -382,7 +382,7 @@ export default class Init extends BaseCommand<typeof Init> {
   async installSdk(packageManager: PackageManager, branchDetails: Schemas.DBBranch) {
     if (isBranchPgRollEnabled(branchDetails)) {
       const sdkVersion = await this.getSdkVersion();
-      if (!sdkVersion) {
+      if (!sdkVersion || sdkVersion?.includes('next')) {
         await this.installPackage(packageManager, '@xata.io/client@next');
         return;
       } else if (!sdkVersion?.includes('next')) {


### PR DESCRIPTION
Related https://xata-hq.slack.com/archives/C032EKCBUGM/p1725437461920159

This PR fixes the issue where the user is on a pgroll enabled branch with xata.io/client@next already specified in their package.json and xata init installs the latest client instead.
