### PR TITLE
Update `createDatabase` call in drizzle test

### DIFF
--- a/packages/plugin-client-drizzle/test/drizzle.test.ts
+++ b/packages/plugin-client-drizzle/test/drizzle.test.ts
@@ -82,8 +82,7 @@ describe.concurrent.each([{ type: 'pg' }, { type: 'http' }])('Drizzle $type', ({
   beforeAll(async () => {
     await api.databases.createDatabase({
       pathParams: { workspaceId: workspace, dbName },
-      body: { region, branchName: 'main' },
-      headers: { 'X-Features': 'feat-pgroll-migrations=1' }
+      body: { region, branchName: 'main', postgresEnabled: true }
     });
 
     await waitForReplication(dbName);


### PR DESCRIPTION
Using the `X-Features` header to make a database postgres-enabled is no longer supported. 

Set the `postgresEnabled` field in the request body instead.
