### PR TITLE
Set postgres enabled state via request body in E2E and drizzle `next` tests

### DIFF
--- a/packages/client/src/api/controlPlaneComponents.ts
+++ b/packages/client/src/api/controlPlaneComponents.ts
@@ -1495,6 +1495,12 @@ export type CreateDatabaseRequestBody = {
    */
   region: string;
   /**
+   * Enable postgres access for this database
+   *
+   * @default false
+   */
+  postgresEnabled?: boolean;
+  /**
    * The dedicated cluster where branches from this database will be created. Defaults to 'shared-cluster'.
    *
    * @minLength 1

--- a/packages/plugin-client-drizzle/test/drizzle.test.ts
+++ b/packages/plugin-client-drizzle/test/drizzle.test.ts
@@ -80,8 +80,7 @@ describe.concurrent.each([{ type: 'pg' }, { type: 'http' }])('Drizzle $type', ({
   beforeAll(async () => {
     await api.databases.createDatabase({
       pathParams: { workspaceId: workspace, dbName: database },
-      body: { region, branchName: 'main' },
-      headers: { 'X-Features': 'feat-pgroll-migrations=1' }
+      body: { region, branchName: 'main', postgresEnabled: true }
     });
 
     await waitForReplication();

--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -80,8 +80,7 @@ export async function setUpTestEnvironment(
 
   const { databaseName: database } = await api.databases.createDatabase({
     pathParams: { workspaceId: workspace, dbName: `sdk-integration-test-${prefix}-${id}` },
-    body: { region, defaultClusterID: clusterId },
-    headers: { 'X-Features': 'feat-pgroll-migrations=1' }
+    body: { region, defaultClusterID: clusterId, postgresEnabled: true }
   });
 
   const workspaceUrl = getHostUrl(host, 'workspaces').replace('{workspaceId}', workspace).replace('{region}', region);


### PR DESCRIPTION
Set the postgres-enabled state of the database via the request body rather than the  now unsupported `X-Features` header.

This fixes failing E2E tests on the `next` branch.

The kyesly test failure in the **Build PR/test** step is unrelated to the changes in this branch; the same tests fail on `next` with no changes. https://github.com/xataio/client-ts/pull/1566 was merged with the same failure.