### PR TITLE
Fix/csv import existing table

### DIFF
--- a/.changeset/quick-sheep-buy.md
+++ b/.changeset/quick-sheep-buy.md
@@ -1,0 +1,5 @@
+---
+'@xata.io/cli': patch
+---
+
+add ability to import new data to existing tables

--- a/cli/src/commands/import/csv.test.ts
+++ b/cli/src/commands/import/csv.test.ts
@@ -3,28 +3,34 @@ import { splitCommas } from './csv';
 import { compareSchemas } from '../../utils/compareSchema';
 import { Schemas } from '@xata.io/client';
 
+const defaultTableInfo = {
+  name: 'one',
+  xataCompatible: true,
+  comment: '',
+  primaryKey: ['id'],
+  uniqueConstraints: {},
+  checkConstraints: {},
+  foreignKeys: {},
+  indexes: {},
+  oid: ''
+};
+const sharedIdCol = {
+  id: {
+    name: 'id',
+    type: 'integer',
+    comment: '',
+    nullable: false,
+    unique: true,
+    default: null
+  }
+};
 const sourceSchemaDefault: Schemas.BranchSchema = {
   name: 'main',
   tables: {
     one: {
-      name: 'one',
-      xataCompatible: true,
-      comment: '',
-      primaryKey: ['id'],
-      uniqueConstraints: {},
-      checkConstraints: {},
-      foreignKeys: {},
-      indexes: {},
-      oid: '',
+      ...defaultTableInfo,
       columns: {
-        id: {
-          name: 'id',
-          type: 'integer',
-          comment: '',
-          nullable: false,
-          unique: true,
-          default: null
-        },
+        ...sharedIdCol,
         colToDelete: {
           name: 'colToDelete',
           type: 'text',
@@ -42,24 +48,9 @@ const targetSchemaDefault: Schemas.BranchSchema = {
   name: 'main',
   tables: {
     one: {
-      name: 'one',
-      xataCompatible: true,
-      comment: '',
-      primaryKey: ['id'],
-      uniqueConstraints: {},
-      checkConstraints: {},
-      foreignKeys: {},
-      indexes: {},
-      oid: '',
+      ...defaultTableInfo,
       columns: {
-        id: {
-          name: 'id',
-          type: 'integer',
-          comment: '',
-          nullable: false,
-          unique: true,
-          default: null
-        },
+        ...sharedIdCol,
         newCol: {
           name: 'newCol',
           type: 'text',

--- a/cli/src/commands/import/csv.test.ts
+++ b/cli/src/commands/import/csv.test.ts
@@ -1,5 +1,77 @@
 import { describe, expect, test } from 'vitest';
 import { splitCommas } from './csv';
+import { compareSchemas } from '../../utils/compareSchema';
+import { Schemas } from '@xata.io/client';
+
+const sourceSchemaDefault: Schemas.BranchSchema = {
+  name: 'main',
+  tables: {
+    one: {
+      name: 'one',
+      xataCompatible: true,
+      comment: '',
+      primaryKey: ['id'],
+      uniqueConstraints: {},
+      checkConstraints: {},
+      foreignKeys: {},
+      indexes: {},
+      oid: '',
+      columns: {
+        id: {
+          name: 'id',
+          type: 'integer',
+          comment: '',
+          nullable: false,
+          unique: true,
+          default: null
+        },
+        colToDelete: {
+          name: 'colToDelete',
+          type: 'text',
+          comment: '',
+          nullable: false,
+          unique: false,
+          default: null
+        }
+      }
+    }
+  }
+};
+
+const targetSchemaDefault: Schemas.BranchSchema = {
+  name: 'main',
+  tables: {
+    one: {
+      name: 'one',
+      xataCompatible: true,
+      comment: '',
+      primaryKey: ['id'],
+      uniqueConstraints: {},
+      checkConstraints: {},
+      foreignKeys: {},
+      indexes: {},
+      oid: '',
+      columns: {
+        id: {
+          name: 'id',
+          type: 'integer',
+          comment: '',
+          nullable: false,
+          unique: true,
+          default: null
+        },
+        newCol: {
+          name: 'newCol',
+          type: 'text',
+          comment: '',
+          nullable: false,
+          unique: false,
+          default: null
+        }
+      }
+    }
+  }
+};
 
 describe('splitCommas', () => {
   test('returns [] for falsy values', () => {
@@ -13,3 +85,94 @@ describe('splitCommas', () => {
     expect(splitCommas('a,b,c')).toEqual(['a', 'b', 'c']);
   });
 });
+
+describe('compare schemas', () => {
+  test('returns an empty array for identical schemas', () => {
+    const { edits } = compareSchemas({ source: sourceSchemaDefault, target: sourceSchemaDefault });
+    expect(edits).toEqual([]);
+  });
+  test('ignores internal columns on source', () => {
+    const { edits } = compareSchemas({
+      source: {
+        ...sourceSchemaDefault,
+        tables: {
+          ...sourceSchemaDefault.tables,
+          one: {
+            ...sourceSchemaDefault.tables.one,
+            columns: {
+              ...sourceSchemaDefault.tables.one.columns,
+              xata_id: {
+                name: 'xata_id',
+                type: 'text',
+                comment: '',
+                nullable: false,
+                unique: false,
+                default: null
+              }
+            }
+          }
+        }
+      },
+      target: targetSchemaDefault
+    });
+    expect(edits).toMatchInlineSnapshot(compareSnapshot);
+  });
+  test('ignores internal columns on target', () => {
+    const { edits } = compareSchemas({
+      source: sourceSchemaDefault,
+      target: {
+        ...targetSchemaDefault,
+        tables: {
+          ...targetSchemaDefault.tables,
+          one: {
+            ...targetSchemaDefault.tables.one,
+            columns: {
+              ...targetSchemaDefault.tables.one.columns,
+              xata_id: {
+                name: 'xata_id',
+                type: 'text',
+                comment: '',
+                nullable: false,
+                unique: false,
+                default: null
+              }
+            }
+          }
+        }
+      }
+    });
+    expect(edits).toMatchInlineSnapshot(compareSnapshot);
+  });
+  test('returns an array with add_column for new columns', () => {
+    const { edits } = compareSchemas({ source: sourceSchemaDefault, target: targetSchemaDefault });
+    expect(edits).toMatchInlineSnapshot(compareSnapshot);
+  });
+  test('returns an array with drop_column for deleted columns', () => {
+    const { edits } = compareSchemas({ source: sourceSchemaDefault, target: targetSchemaDefault });
+    expect(edits).toMatchInlineSnapshot(compareSnapshot);
+  });
+});
+
+const compareSnapshot = `
+[
+  {
+    "add_column": {
+      "column": {
+        "comment": "",
+        "default": undefined,
+        "name": "newCol",
+        "nullable": false,
+        "references": undefined,
+        "type": "text",
+        "unique": false,
+      },
+      "table": "one",
+    },
+  },
+  {
+    "drop_column": {
+      "column": "colToDelete",
+      "table": "one",
+    },
+  },
+]`;

--- a/cli/src/commands/import/csv.test.ts
+++ b/cli/src/commands/import/csv.test.ts
@@ -134,6 +134,39 @@ describe('compare schemas', () => {
     });
     expect(edits).toMatchInlineSnapshot(compareSnapshot);
   });
+  test('returns an array with create table if table does not already exist', () => {
+    const { edits } = compareSchemas({ source: {}, target: targetSchemaDefault });
+    expect(edits).toMatchInlineSnapshot(`
+      [
+        {
+          "create_table": {
+            "columns": [
+              {
+                "comment": "",
+                "default": undefined,
+                "name": "id",
+                "nullable": false,
+                "references": undefined,
+                "type": "integer",
+                "unique": true,
+              },
+              {
+                "comment": "",
+                "default": undefined,
+                "name": "newCol",
+                "nullable": false,
+                "references": undefined,
+                "type": "text",
+                "unique": false,
+              },
+            ],
+            "comment": "",
+            "name": "one",
+          },
+        },
+      ]
+    `);
+  });
   test('returns an array with add_column for new columns', () => {
     const { edits } = compareSchemas({ source: sourceSchemaDefault, target: targetSchemaDefault });
     expect(edits).toMatchInlineSnapshot(compareSnapshot);

--- a/cli/src/utils/compareSchema.ts
+++ b/cli/src/utils/compareSchema.ts
@@ -2,11 +2,15 @@ import { PgRollOperation } from '@xata.io/pgroll';
 import { PartialDeep } from 'type-fest';
 import { Schemas } from '@xata.io/client';
 import { generateLinkReference, tableNameFromLinkComment, xataColumnTypeToPgRoll } from '../migrations/pgroll.js';
+import { INTERNAL_COLUMNS_PGROLL } from '../commands/import/csv.js';
 
-export function compareSchemas(
-  source: PartialDeep<Schemas.BranchSchema>,
-  target: PartialDeep<Schemas.BranchSchema>
-): { edits: PgRollOperation[] } {
+export function compareSchemas({
+  source,
+  target
+}: {
+  source: PartialDeep<Schemas.BranchSchema>;
+  target: PartialDeep<Schemas.BranchSchema>;
+}): { edits: PgRollOperation[] } {
   const edits: PgRollOperation[] = [];
 
   // Compare tables
@@ -17,8 +21,12 @@ export function compareSchemas(
 
   // Compare columns
   for (const table of sourceTables) {
-    const sourceColumns = Object.keys(source.tables?.[table]?.columns ?? {});
-    const targetColumns = Object.keys(target.tables?.[table]?.columns ?? {});
+    const sourceColumns = Object.keys(source.tables?.[table]?.columns ?? {}).filter(
+      (c) => !INTERNAL_COLUMNS_PGROLL.includes(c)
+    );
+    const targetColumns = Object.keys(target.tables?.[table]?.columns ?? {}).filter(
+      (c) => !INTERNAL_COLUMNS_PGROLL.includes(c)
+    );
     const newColumns = targetColumns.filter((column) => !sourceColumns.includes(column));
     const deletedColumns = sourceColumns.filter((column) => !targetColumns.includes(column));
 
@@ -53,43 +61,43 @@ export function compareSchemas(
     }
 
     // Compare column properties
-    for (const column of targetColumns) {
-      const sourceProps = source.tables?.[table]?.columns?.[column] ?? {};
-      const targetProps = target.tables?.[table]?.columns?.[column] ?? {};
+    // for (const column of targetColumns) {
+    //   const sourceProps = source.tables?.[table]?.columns?.[column] ?? {};
+    //   const targetProps = target.tables?.[table]?.columns?.[column] ?? {};
 
-      if (sourceProps.type !== targetProps.type) {
-        edits.push({
-          alter_column: {
-            table,
-            column,
-            type: targetProps.type,
-            references:
-              targetProps?.type === 'link' && targetProps?.name
-                ? generateLinkReference({
-                    column: targetProps.name,
-                    table: tableNameFromLinkComment(targetProps?.comment ?? '') ?? ''
-                  })
-                : undefined
-          }
-        });
-      }
+    //   if (sourceProps.type !== targetProps.type) {
+    //     edits.push({
+    //       alter_column: {
+    //         table,
+    //         column,
+    //         type: targetProps.type,
+    //         references:
+    //           targetProps?.type === 'link' && targetProps?.name
+    //             ? generateLinkReference({
+    //                 column: targetProps.name,
+    //                 table: tableNameFromLinkComment(targetProps?.comment ?? '') ?? ''
+    //               })
+    //             : undefined
+    //       }
+    //     });
+    //   }
 
-      if (sourceProps.nullable !== targetProps.nullable) {
-        edits.push({ alter_column: { table, column, nullable: targetProps.nullable } });
-      }
+    //   if (sourceProps.nullable !== targetProps.nullable) {
+    //     edits.push({ alter_column: { table, column, nullable: targetProps.nullable } });
+    //   }
 
-      if (sourceProps.unique !== targetProps.unique) {
-        edits.push({
-          alter_column: {
-            table,
-            column,
-            unique: {
-              name: `${table}_${column}_unique`
-            }
-          }
-        });
-      }
-    }
+    //   if (sourceProps.unique !== targetProps.unique) {
+    //     edits.push({
+    //       alter_column: {
+    //         table,
+    //         column,
+    //         unique: {
+    //           name: `${table}_${column}_unique`
+    //         }
+    //       }
+    //     });
+    //   }
+    // }
   }
 
   // Delete tables
@@ -127,3 +135,92 @@ export function compareSchemas(
 
   return { edits };
 }
+
+export const inferOldSchemaToNew = (oldSchema: Schemas.DBBranch): Schemas.BranchSchema => {
+  const schema: Schemas.BranchSchema = {
+    name: oldSchema.branchName,
+    tables: Object.fromEntries(
+      oldSchema.schema.tables.map((table) => [
+        table.name,
+        {
+          name: table.name,
+          xataCompatible: true,
+          comment: '',
+          primaryKey: 'id',
+          uniqueConstraints: [],
+          checkConstraints: [],
+          foreignKeys: [],
+          columns: Object.fromEntries(
+            table.columns.map((column) => [
+              column.name,
+              {
+                name: column.name,
+                type: oldColumnTypeToNew(column),
+                comment: generateCommentFromOldColumn(column),
+                nullable: !(column.notNull === true),
+                unique: column.unique === true,
+                defaultValue: column.defaultValue
+              }
+            ])
+          )
+        }
+      ]) as any
+    )
+  };
+
+  return schema;
+};
+
+const oldColumnTypeToNew = (oldColumn: Schemas.Column) => {
+  // These types will be limited to the original deprecated Xata types
+  switch (oldColumn.type) {
+    case 'bool':
+      return 'boolean';
+    case 'datetime':
+      return 'timestamptz';
+    case 'vector':
+      return 'vector';
+    case 'json':
+      return 'jsonb';
+    case 'file':
+      return 'xata_file';
+    case 'file[]':
+      return 'xata_file_array';
+    case 'int':
+      return 'integer';
+    case 'float':
+      return 'real';
+    case 'multiple':
+      return 'text[]';
+    case 'text':
+    case 'string':
+    case 'email':
+      return 'text';
+    case 'link':
+      return 'link';
+    default:
+      return 'text';
+  }
+};
+
+const generateCommentFromOldColumn = (oldColumn: Schemas.Column) => {
+  switch (oldColumn.type) {
+    case 'vector':
+      return JSON.stringify({ 'xata.search.dimension': oldColumn.vector?.dimension });
+    case 'file':
+      return JSON.stringify({ 'xata.file.dpa': oldColumn?.file?.defaultPublicAccess });
+    case 'file[]':
+      return JSON.stringify({ 'xata.file.dpa': oldColumn?.['file[]']?.defaultPublicAccess });
+    case 'link':
+      return oldColumn.link?.table ? generateLinkComment(oldColumn.link?.table) : '';
+    case 'string':
+    case 'email':
+      return JSON.stringify({ 'xata.type': oldColumn.type });
+    default:
+      return '';
+  }
+};
+
+const generateLinkComment = (tableName: string) => {
+  return JSON.stringify({ 'xata.link': tableName });
+};


### PR DESCRIPTION
<!-- Add a nice description here -->

Related: https://xata-hq.slack.com/archives/C032EKCBUGM/p1726051389626059

This PR adds the ability for Postgres users to import new data to existing tables. Before this PR csv import would error if the table already existed.

<!-- Don't forget the `Closed #{issue_number}` -->
