### PR TITLE
Stop sending `X-Xata-Files` header on test database creation

### DIFF
--- a/test/utils/setup.ts
+++ b/test/utils/setup.ts
@@ -81,8 +81,7 @@ export async function setUpTestEnvironment(
 
   const { databaseName: database } = await api.databases.createDatabase({
     pathParams: { workspaceId: workspace, dbName: `sdk-integration-test-${prefix}-${id}` },
-    body: { region },
-    headers: { 'X-Xata-Files': 'true' }
+    body: { region }
   });
 
   const workspaceUrl = getHostUrl(host, 'workspaces').replace('{workspaceId}', workspace).replace('{region}', region);


### PR DESCRIPTION
Stop sending the `X-Xata-Files` header on test database creation.

The backend doesn't do anything with this header.